### PR TITLE
fix NetworkQuery.ts not to reset path after finding playground network

### DIFF
--- a/src/layouts/contexts/PlaygroundContext.tsx
+++ b/src/layouts/contexts/PlaygroundContext.tsx
@@ -54,12 +54,13 @@ function useConnectedPlayground (): boolean {
   const { setNetwork } = useNetworkContext()
   const [isLoaded, setLoaded] = useState(false)
 
-  const environment = getEnvironment()
-  if (!environment.debug) {
-    return true
-  }
-
   useEffect(() => {
+    const environment = getEnvironment()
+    if (!environment.debug) {
+      setLoaded(true)
+      return
+    }
+
     async function findPlayground (): Promise<void> {
       for (const network of environment.networks.filter(isPlayground)) {
         if (await isConnected(network)) {

--- a/src/layouts/contexts/api/NetworkQuery.ts
+++ b/src/layouts/contexts/api/NetworkQuery.ts
@@ -20,24 +20,23 @@ interface NetworkQueryInterface {
 export function useNetworkQuery (): NetworkQueryInterface {
   const env = getEnvironment()
   const router = useRouter()
-  const network = resolveNetwork(router.query['network'])
+  const current = resolveNetwork(router.query['network'])
 
   return {
     getNetwork (): EnvironmentNetwork {
-      return network
+      return current
     },
     setNetwork (network: EnvironmentNetwork) {
       if (!env.networks.includes(network)) {
         throw new Error('network is not part of environment')
       }
-
-      if (isDefaultNetwork(network)) {
-        void router.push({ pathname: '/' })
+      if (current === network) {
+        return
       }
 
       void router.push({
-        pathname: '/',
-        query: { network: network },
+        pathname: router.pathname,
+        query: isDefaultNetwork(network) ? { network: network } : {},
       })
     }
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

