### PR TITLE
Update lint to not allow `variable function` and `export default`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,17 @@
     "next/core-web-vitals"
   ],
   "rules": {
-    "no-void": "off"
-  }
+    "func-style": [2, "declaration"],
+    "no-void": "off",
+    "import/no-default-export": "error"
+  },
+  "overrides": [
+    {
+      "files": ["src/pages/**.tsx"],
+      "rules": {
+        "import/no-default-export": "off",
+        "import/prefer-default-export": "error"
+      }
+    }
+  ]
 }

--- a/src/components/icons/DeFiChainLogo.tsx
+++ b/src/components/icons/DeFiChainLogo.tsx
@@ -1,6 +1,6 @@
 import { SVGProps } from 'react'
 
-export default function DeFiChainLogo (props: SVGProps<SVGSVGElement>): JSX.Element {
+export function DeFiChainLogo (props: SVGProps<SVGSVGElement>): JSX.Element {
   return (
     <svg xmlns='http://www.w3.org/2000/svg' width={156} height={72} viewBox='0 0 156 72' {...props}>
       <path

--- a/src/layouts/Default.tsx
+++ b/src/layouts/Default.tsx
@@ -2,8 +2,8 @@ import Head from 'next/head'
 import { PropsWithChildren } from 'react'
 import { Provider } from 'react-redux'
 import { store } from '../store'
-import Footer from './components/Footer'
-import Header from './components/Header'
+import { Footer } from './components/Footer'
+import { Header } from './components/Header'
 import { KeepNetworkQueryString } from './contexts/api/NetworkQuery'
 import { NetworkProvider } from './contexts/NetworkContext'
 import { PlaygroundProvider } from './contexts/PlaygroundContext'
@@ -16,7 +16,7 @@ import { WhaleProvider } from './contexts/WhaleContext'
  * Followed by <PlaygroundProvider> to automatically swatch between local and remote playground for debug environment.
  * Finally with <WhaleProvider> to provide WhaleContext for accessing of WhaleAPI and WhaleRPC.
  */
-export default function Default (props: PropsWithChildren<any>): JSX.Element | null {
+export function Default (props: PropsWithChildren<any>): JSX.Element | null {
   return (
     <div className='flex flex-col min-h-screen'>
       <Head>

--- a/src/layouts/components/Footer.tsx
+++ b/src/layouts/components/Footer.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
-import DeFiChainLogo from '../../components/icons/DeFiChainLogo'
+import { DeFiChainLogo } from '../../components/icons/DeFiChainLogo'
 
-export default function Footer (): JSX.Element {
+export function Footer (): JSX.Element {
   return (
     <footer className='mt-12 border-t border-gray-100'>
       <div className='container mx-auto px-4 py-12'>

--- a/src/layouts/components/Header.tsx
+++ b/src/layouts/components/Header.tsx
@@ -1,11 +1,11 @@
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
-import DeFiChainLogo from '../../components/icons/DeFiChainLogo'
+import { DeFiChainLogo } from '../../components/icons/DeFiChainLogo'
 import { getEnvironment } from '../contexts/api/Environment'
 import { useNetworkContext } from '../contexts/NetworkContext'
 import { useWhaleRpcClient } from '../contexts/WhaleContext'
 
-export default function Header (): JSX.Element {
+export function Header (): JSX.Element {
   const { network } = useNetworkContext()
   const rpc = useWhaleRpcClient()
   const [count, setCount] = useState(0)

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,6 @@
 import '../styles/globals.css'
 import App, { AppContext } from 'next/app'
-import Default from '../layouts/Default'
+import { Default } from '../layouts/Default'
 
 function ScanApp ({ Component, pageProps }): JSX.Element {
   return (


### PR DESCRIPTION
#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore


- Do not allow `export default` as it makes large scaling refactoring effort difficult.
- Top level functions should not use arrow syntax.

