### PR TITLE
Changed the rules for the overridding no-default-export rules to appl…

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,7 @@
   },
   "overrides": [
     {
-      "files": ["src/pages/**.tsx"],
+      "files": ["src/pages/**/*.tsx"],
       "rules": {
         "import/no-default-export": "off",
         "import/prefer-default-export": "error"


### PR DESCRIPTION
…y recursively in pages folder.

<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:
The current lint rule for overridding no-default-export does not apply recursively for all the files in the `src/pages` directory but only applies for it's immediate child files.

We need this for nested routes like `/blocks/:id/transactions`:
<img width="227" alt="image" src="https://user-images.githubusercontent.com/4145525/127606268-a5301990-950e-4013-b738-6051ecf5156c.png">