### PR TITLE
new domain: `https://defiscan.live`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/9e2e89a0c9cfa93478eb/maintainability)](https://codeclimate.com/github/DeFiCh/scan/maintainability)
 [![TS-Standard](https://badgen.net/badge/code%20style/ts-standard/blue?icon=typescript)](https://github.com/standard/ts-standard)
 
-# [DeFi Scan](https://defiscan.xyz)
+# [DeFi Scan](https://defiscan.live)
 
-> https://defiscan.xyz
+> https://defiscan.live
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/7c8f536f-028f-493f-953f-293dcde36f89/deploy-status)](https://app.netlify.com/sites/defi-scan/deploys)
 
@@ -41,6 +41,7 @@ To learn more about Next.js, take a look at the following resources:
 
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+- [Netlify Plugin NextJs](https://github.com/netlify/netlify-plugin-nextjs) SSR is enabled by default.
 
 ### Project Structure
 
@@ -59,8 +60,8 @@ scan/
 └─ cypress/
 ```
 
-DeFi Scan project is structured with 2 core directories. Each pull request will likely carry significant changes
-into those directories.
+DeFi Scan project is structured with 2 core directories. Each pull request will likely carry significant changes into
+those directories.
 
 Directory               | Description
 ------------------------|-------------
@@ -75,7 +76,7 @@ Directory               | Description
 
 ### End-to-end Testing
 
-End-to-end testing tests the entire lifecycle of DeFi Scan. All components and screen are integrated together as
+End-to-end testing; tests the entire lifecycle of DeFi Scan. All components and screen are integrated together as
 expected for real use cases. As such test are written for real usage narrative as a normal consumer would. They are
 placed in the `/cypress` directory, and we use [Cypress](https://github.com/cypress-io/cypress) to facilitate the
 testing.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,20 @@
 [[plugins]]
 package = "@netlify/plugin-lighthouse"
+
+[[redirects]]
+from = "https://defiscan.xyz"
+to = "https://defiscan.live"
+status = 301
+force = true
+
+[[redirects]]
+from = "https://defiscan.dev"
+to = "https://defiscan.live"
+status = 301
+force = true
+
+[[redirects]]
+from = "https://defiscan.to"
+to = "https://defiscan.live"
+status = 301
+force = true

--- a/src/layouts/contexts/WhaleContext.tsx
+++ b/src/layouts/contexts/WhaleContext.tsx
@@ -1,10 +1,26 @@
 import { WhaleApiClient, WhaleRpcClient } from '@defichain/whale-api-client'
+import { GetServerSidePropsContext } from 'next'
 import { createContext, PropsWithChildren, useContext, useMemo } from 'react'
 import { EnvironmentNetwork } from './api/Environment'
 import { useNetworkContext } from './NetworkContext'
 
 const WhaleApiClientContext = createContext<WhaleApiClient>(undefined as any)
 const WhaleRpcClientContext = createContext<WhaleRpcClient>(undefined as any)
+
+/**
+ * getWhaleApiClient from GetServerSidePropsContext.
+ * @example
+ * function getServerSideProps(context: GetServerSidePropsContext) {
+ *   const client = getWhaleApiClient(context)
+ * }
+ *
+ * @param {GetServerSidePropsContext} context to read from SSR
+ * @return WhaleApiClient created from query string of GetServerSidePropsContext
+ */
+export function getWhaleApiClient (context: GetServerSidePropsContext): WhaleApiClient {
+  const network = context.query.network?.toString()
+  return newWhaleClient(network as EnvironmentNetwork)
+}
 
 export function useWhaleApiClient (): WhaleApiClient {
   return useContext(WhaleApiClientContext)

--- a/src/layouts/contexts/index.ts
+++ b/src/layouts/contexts/index.ts
@@ -1,4 +1,4 @@
 export { useNetworkContext } from './NetworkContext'
 export { usePlaygroundContext } from './PlaygroundContext'
-export { useWhaleApiClient, useWhaleRpcClient } from './WhaleContext'
+export { useWhaleApiClient, useWhaleRpcClient, getWhaleApiClient } from './WhaleContext'
 export { getEnvironment } from './api/Environment'


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

[Netlify Plugin NextJs](https://github.com/netlify/netlify-plugin-nextjs) SSR is enabled by default for netlify deployment. Also added `getWhaleApiClient(GetServerSidePropsContext)` to get WhaleApiClient from `getServerSideProps()`.

```ts
import { getWhaleApiClient } from '@contexts'

async function getServerSideProps(context: GetServerSidePropsContext): Promise<GetServerSidePropsResult<any>> {
  const client = getWhaleApiClient(context)
  return { 
    props: { prices: await client.prices.list() }
  }
}
```

Added `[[redirects]]` to redirect all domains to `https://defiscan.live`.