### PR TITLE
added custom keep network `<Link/>` implementation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,14 @@
   "rules": {
     "func-style": [2, "declaration"],
     "no-void": "off",
-    "import/no-default-export": "error"
+    "import/no-default-export": "error",
+    "no-restricted-imports": [
+      "error",
+      {
+        "name": "next/link",
+        "message": "Please use @components/commons/Link instead."
+      }
+    ]
   },
   "overrides": [
     {

--- a/src/components/commons/Link.tsx
+++ b/src/components/commons/Link.tsx
@@ -1,0 +1,45 @@
+import { EnvironmentNetwork, getEnvironment, useNetworkContext } from '@contexts'
+import { LinkProps as NextLinkProps } from 'next/dist/client/link'
+/* eslint-disable no-restricted-imports */
+import NextLink from 'next/link'
+import { PropsWithChildren } from 'react'
+import { UrlObject } from 'url'
+
+export interface LinkUrlObject extends UrlObject {
+  query?: Record<string, string>
+}
+
+interface LinkProps extends NextLinkProps {
+  href: LinkUrlObject
+}
+
+/**
+ * Overrides the default next/link to provide ability to 'keep ?network= query string'.
+ * This allows `<Link>` usage to be network agnostic where ?network= are automatically appended.
+ *
+ * To keep implementation simple, LinkProps enforce href to be strictly a `UrlObject` object
+ * where query is a `Record<string, string>`. Hence only use this for internal linking.
+ *
+ * @param {PropsWithChildren<LinkProps>} props
+ */
+export function Link (props: PropsWithChildren<LinkProps>): JSX.Element {
+  const { network } = useNetworkContext()
+
+  if (!isDefaultNetwork(network)) {
+    props.href.query = {
+      ...props.href.query ?? {},
+      network: network
+    }
+  }
+
+  return (
+    <NextLink {...props}>
+      {props.children}
+    </NextLink>
+  )
+}
+
+function isDefaultNetwork (network: EnvironmentNetwork): boolean {
+  const env = getEnvironment()
+  return env.networks[0] === network
+}

--- a/src/layouts/Default.tsx
+++ b/src/layouts/Default.tsx
@@ -4,7 +4,6 @@ import { Provider } from 'react-redux'
 import { store } from '../store'
 import { Footer } from './components/Footer'
 import { Header } from './components/Header'
-import { KeepNetworkQueryString } from './contexts/api/NetworkQuery'
 import { NetworkProvider } from './contexts/NetworkContext'
 import { PlaygroundProvider } from './contexts/PlaygroundContext'
 import { WhaleProvider } from './contexts/WhaleContext'
@@ -42,15 +41,13 @@ export function Default (props: PropsWithChildren<any>): JSX.Element | null {
         <PlaygroundProvider>
           <WhaleProvider>
             <Provider store={store}>
-              <KeepNetworkQueryString>
-                <Header />
+              <Header />
 
-                <main className='flex-grow'>
-                  {props.children}
-                </main>
+              <main className='flex-grow'>
+                {props.children}
+              </main>
 
-                <Footer />
-              </KeepNetworkQueryString>
+              <Footer />
             </Provider>
           </WhaleProvider>
         </PlaygroundProvider>

--- a/src/layouts/components/Footer.tsx
+++ b/src/layouts/components/Footer.tsx
@@ -36,8 +36,8 @@ export function Footer (): JSX.Element {
 
             <div className='mt-3'>
               <div className='-mx-2'>
-                <FooterTinyLink href='https://defichain.com/white-paper/' text='White Paper' />
-                <FooterTinyLink href='https://defichain.com/privacy-policy/' text='Privacy Policy' />
+                <FooterTinyLink url='https://defichain.com/white-paper/' text='White Paper' />
+                <FooterTinyLink url='https://defichain.com/privacy-policy/' text='Privacy Policy' />
               </div>
             </div>
           </div>
@@ -47,11 +47,11 @@ export function Footer (): JSX.Element {
   )
 }
 
-function FooterTinyLink (props: { text: string, href: string }): JSX.Element {
+function FooterTinyLink (props: { text: string, url: string }): JSX.Element {
   return (
     <a
       className='p-2 text-xs text-gray-700 font-semibold hover:text-primary cursor-pointer'
-      href={props.href}
+      href={props.url}
       target='_blank' rel='noreferrer'
     >
       {props.text}

--- a/src/layouts/components/Footer.tsx
+++ b/src/layouts/components/Footer.tsx
@@ -1,11 +1,11 @@
+import { Link } from '@components/commons/Link'
 import { DeFiChainLogo } from '@components/icons/DeFiChainLogo'
-import Link from 'next/link'
 
 export function Footer (): JSX.Element {
   return (
     <footer className='mt-12 border-t border-gray-100'>
       <div className='container mx-auto px-4 py-12'>
-        <Link href='/' passHref>
+        <Link href={{ pathname: '/' }} passHref>
           <div className='cursor-pointer'>
             <DeFiChainLogo className='w-28 h-full' />
           </div>
@@ -16,13 +16,13 @@ export function Footer (): JSX.Element {
             <div className='text-2xl font-semibold'>Scan</div>
 
             <div className='flex flex-wrap mt-3 -m-2 w-72'>
-              <FooterInternalLink href='https://mainnet.defichain.io/#/DFI/mainnet/home' text='Blocks' />
-              <FooterInternalLink href='https://dex.defichain.com/mainnet/pool' text='DEX' />
-              <FooterInternalLink href='/prices' text='Prices' />
-              {/* <FooterInternalLink href='/icx' text='ICX' /> */}
-              <FooterInternalLink href='https://dex.defichain.com/mainnet/token' text='Tokens' />
-              {/* <FooterInternalLink href='/masternodes' text='Masternodes' /> */}
-              <FooterInternalLink href='https://dex.defichain.com/mainnet/anchors' text='BTC Anchors' />
+              <FooterExternalLink url='https://mainnet.defichain.io/#/DFI/mainnet/home' text='Blocks' />
+              <FooterExternalLink url='https://dex.defichain.com/mainnet/pool' text='DEX' />
+              <FooterInternalLink pathname='/prices' text='Prices' />
+              {/* <FooterInternalLink pathname='/icx' text='ICX' /> */}
+              <FooterExternalLink url='https://dex.defichain.com/mainnet/token' text='Tokens' />
+              {/* <FooterInternalLink pathname='/masternodes' text='Masternodes' /> */}
+              <FooterExternalLink url='https://dex.defichain.com/mainnet/anchors' text='BTC Anchors' />
             </div>
           </div>
 
@@ -36,8 +36,8 @@ export function Footer (): JSX.Element {
 
             <div className='mt-3'>
               <div className='-mx-2'>
-                <FooterExternalLink href='https://defichain.com/white-paper/' text='White Paper' />
-                <FooterExternalLink href='https://defichain.com/privacy-policy/' text='Privacy Policy' />
+                <FooterTinyLink href='https://defichain.com/white-paper/' text='White Paper' />
+                <FooterTinyLink href='https://defichain.com/privacy-policy/' text='Privacy Policy' />
               </div>
             </div>
           </div>
@@ -47,7 +47,7 @@ export function Footer (): JSX.Element {
   )
 }
 
-function FooterExternalLink (props: { text: string, href: string }): JSX.Element {
+function FooterTinyLink (props: { text: string, href: string }): JSX.Element {
   return (
     <a
       className='p-2 text-xs text-gray-700 font-semibold hover:text-primary cursor-pointer'
@@ -59,12 +59,22 @@ function FooterExternalLink (props: { text: string, href: string }): JSX.Element
   )
 }
 
-function FooterInternalLink (props: { text: string, href: string }): JSX.Element {
+function FooterInternalLink (props: { text: string, pathname: string }): JSX.Element {
   return (
     <div className='p-2 w-1/2 text-lg hover:text-primary cursor-pointer'>
-      <Link href={props.href}>
+      <Link href={{ pathname: props.pathname }}>
         {props.text}
       </Link>
+    </div>
+  )
+}
+
+function FooterExternalLink (props: { text: string, url: string }): JSX.Element {
+  return (
+    <div className='p-2 w-1/2 text-lg hover:text-primary cursor-pointer'>
+      <a href={props.url}>
+        {props.text}
+      </a>
     </div>
   )
 }

--- a/src/layouts/components/Header.tsx
+++ b/src/layouts/components/Header.tsx
@@ -1,7 +1,7 @@
+import { Link } from '@components/commons/Link'
 import { DeFiChainLogo } from '@components/icons/DeFiChainLogo'
 import { getEnvironment, useNetworkContext, useWhaleRpcClient } from '@contexts'
 import { Menu, Transition } from '@headlessui/react'
-import Link from 'next/link'
 import { Fragment, useEffect, useState } from 'react'
 import { MdArrowDropDown } from 'react-icons/md'
 import NumberFormat from 'react-number-format'
@@ -21,7 +21,7 @@ export function Header (): JSX.Element {
       <div className='border-b border-gray-100'>
         <div className='container mx-auto px-4 py-8'>
           <div className='flex items-center'>
-            <Link href='/' passHref>
+            <Link href={{ pathname: '/' }} passHref>
               <div className='flex items-center cursor-pointer hover:text-primary'>
                 <DeFiChainLogo className='w-16 h-full' />
                 <h6 className='ml-3 text-xl font-medium'>Scan</h6>

--- a/src/layouts/contexts/WhaleContext.tsx
+++ b/src/layouts/contexts/WhaleContext.tsx
@@ -19,7 +19,7 @@ const WhaleRpcClientContext = createContext<WhaleRpcClient>(undefined as any)
  */
 export function getWhaleApiClient (context: GetServerSidePropsContext): WhaleApiClient {
   const network = context.query.network?.toString()
-  return newWhaleClient(network as EnvironmentNetwork)
+  return newWhaleClient(network)
 }
 
 export function useWhaleApiClient (): WhaleApiClient {
@@ -48,9 +48,10 @@ export function WhaleProvider (props: PropsWithChildren<any>): JSX.Element | nul
   )
 }
 
-function newWhaleClient (network: EnvironmentNetwork): WhaleApiClient {
+function newWhaleClient (network?: string): WhaleApiClient {
   switch (network) {
     case EnvironmentNetwork.MainNet:
+    default:
       return new WhaleApiClient({ url: 'https://ocean.defichain.com', network: 'mainnet' })
     case EnvironmentNetwork.TestNet:
       return new WhaleApiClient({ url: 'https://ocean.defichain.com', network: 'testnet' })

--- a/src/layouts/contexts/api/NetworkQuery.tsx
+++ b/src/layouts/contexts/api/NetworkQuery.tsx
@@ -1,7 +1,5 @@
-import { useNetworkContext } from '@contexts'
+import { EnvironmentNetwork, getEnvironment } from '@contexts'
 import { useRouter } from 'next/router'
-import { PropsWithChildren, useEffect } from 'react'
-import { EnvironmentNetwork, getEnvironment } from './Environment'
 
 interface NetworkQueryInterface {
   /**
@@ -48,11 +46,6 @@ function isDefaultNetwork (network: EnvironmentNetwork): boolean {
   return env.networks[0] === network
 }
 
-function hasNetwork (url: string): boolean {
-  const query = url.split('?')[1]
-  return new URLSearchParams(query).has('network')
-}
-
 function resolveNetwork (text?: string | string[]): EnvironmentNetwork {
   const env = getEnvironment()
 
@@ -61,42 +54,4 @@ function resolveNetwork (text?: string | string[]): EnvironmentNetwork {
   }
 
   return env.networks[0]
-}
-
-export function KeepNetworkQueryString (props: PropsWithChildren<any>): JSX.Element {
-  const router = useRouter()
-  const { network } = useNetworkContext()
-
-  useEffect(() => {
-    function routeChangeComplete (url: string, options: { shadow: boolean }): void {
-      const [pathname, search] = url.split('?')
-
-      if (options.shadow) {
-        return
-      }
-
-      if (hasNetwork(url)) {
-        return
-      }
-
-      if (isDefaultNetwork(network)) {
-        return
-      }
-
-      void router.replace({
-        pathname: pathname,
-        query: {
-          ...Object.fromEntries(new URLSearchParams(search).entries()),
-          network: network
-        }
-      }, undefined, { shallow: true })
-    }
-
-    router.events.on('routeChangeComplete', routeChangeComplete)
-    return () => {
-      router.events.off('routeChangeComplete', routeChangeComplete)
-    }
-  }, [network])
-
-  return props.children
 }

--- a/src/layouts/contexts/index.ts
+++ b/src/layouts/contexts/index.ts
@@ -1,4 +1,4 @@
 export { useNetworkContext } from './NetworkContext'
 export { usePlaygroundContext } from './PlaygroundContext'
 export { useWhaleApiClient, useWhaleRpcClient, getWhaleApiClient } from './WhaleContext'
-export { getEnvironment } from './api/Environment'
+export { getEnvironment, EnvironmentNetwork, EnvironmentName } from './api/Environment'


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

With the introduction of `getServerSideProps`, `KeepNetworkQueryString` won't suffice to replace URL with network querystring e.g.`?network=Playground`. This proves to be difficult as `getServerSideProps` do not run an environment where `useHook` can be set up.

The alternative will be injecting the required querystring into all `<Link>` implementations. Doing it conditionally and manually at each required `<Link>` reference will a gross and unclean project. Hence, this PR implements `import { Link } from '@components/commons/Link'` where the default next `<Link>` implementation is override to provide `KeepNetworkQueryString` `<Link>` implementation. 


#### Additional comments?:

- eslint is updated to prevent `next/link` usage.
- `KeepNetworkQueryString` has been removed entirely