### PR TITLE
removed `useConnectedPlayground()`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,6 @@ jobs:
 
       - run: npm ci
 
-      - name: Setup Playground
-        run: docker-compose -f docker-compose.yml up -d
-
-      - run: .github/workflows/ci/wait-for http://localhost:3001/_actuator/probes/liveness -t 120
-      - run: .github/workflows/ci/wait-for http://localhost:3002/_actuator/probes/liveness -t 120
-      - run: .github/workflows/ci/wait-for http://localhost:19551/ping -t 120
-
       - uses: cypress-io/github-action@6122aa43014e18ec9c2d06fc0bdc5b6759064508
         with:
           install: false

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ scan/
 ├─ .github/
 ├─ public/
 ├─ src/
+│  ├─ cms/
 │  ├─ components/
 │  ├─ layouts/
 │  ├─ pages/
@@ -67,6 +68,7 @@ Directory               | Description
 ------------------------|-------------
 `/.github`              | workflow for shift left automation
 `/public`               | static resources
+`/src/cms`              | static cms
 `/src/components`       | top level components for a shared design language
 `/src/layouts`          | top level layouts for shared page layout & components
 `/src/pages`            | each page is associated with a route based on its file name

--- a/cypress/integration/layouts/header.spec.ts
+++ b/cypress/integration/layouts/header.spec.ts
@@ -4,6 +4,6 @@ describe('header', () => {
   })
 
   it('should contain block count', function () {
-    cy.get('header ul li:nth-child(1)').should('not.have.text', 'Blocks: 0')
+    cy.get('header ul li:nth-child(1)').should('not.have.text', 'Blocks: ...')
   })
 })

--- a/src/layouts/contexts/api/Environment.ts
+++ b/src/layouts/contexts/api/Environment.ts
@@ -33,8 +33,8 @@ export const environments: Record<EnvironmentName, Environment> = {
     name: EnvironmentName.Development,
     debug: true,
     networks: [
-      EnvironmentNetwork.LocalPlayground,
       EnvironmentNetwork.RemotePlayground,
+      EnvironmentNetwork.LocalPlayground,
       EnvironmentNetwork.TestNet,
       EnvironmentNetwork.MainNet
     ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

with SSR, useConnectedPlayground() to find connected playground is invalid as the network is now configured via querystring instead of the state.

Intermediate network switching proves to be difficult via SSR rendering one network while SPA rendering on another.

Also removed SetupPlayground in ci.yml