### PR TITLE
Breadcrumb.tsx will now interpolate SEO metadata

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,10 @@
       {
         "name": "next/link",
         "message": "Please use @components/commons/Link instead."
+      },
+      {
+        "name": "next/head",
+        "message": "Please use @components/commons/Head instead."
       }
     ]
   },

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="HtmlRequiredTitleElement" enabled="false" level="WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@tailwindcss/line-clamp": "^0.2.1",
         "bignumber.js": "^9.0.1",
         "date-fns": "^2.23.0",
+        "lodash": "^4.17.21",
         "next": "11.0.1",
         "nextjs-progressbar": "^0.0.11",
         "react": "17.0.2",
@@ -23,11 +24,14 @@
         "react-icons": "^4.2.0",
         "react-number-format": "^4.6.4",
         "react-redux": "^7.2.4",
-        "recharts": "^2.0.10"
+        "react-schemaorg": "^2.0.0",
+        "recharts": "^2.0.10",
+        "schema-dts": "^0.10.0"
       },
       "devDependencies": {
         "@cypress/code-coverage": "^3.9.10",
         "@testing-library/cypress": "^8.0.0",
+        "@types/lodash": "^4.14.172",
         "@types/node": "^14.17.7",
         "@types/react": "^17.0.15",
         "autoprefixer": "^10.3.1",
@@ -2650,6 +2654,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.172",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.172.tgz",
+      "integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==",
       "dev": true
     },
     "node_modules/@types/lossless-json": {
@@ -11524,6 +11534,19 @@
         "react-dom": "^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/react-schemaorg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-schemaorg/-/react-schemaorg-2.0.0.tgz",
+      "integrity": "sha512-UqciFKA203ewNjn0zC09uYKuJSvMD8L75L1s/cW4rc7cS64w8l7vaI3SYkuoI/nwCBkJRmOkSJedWDUZBlYZwg==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "schema-dts": ">=0.7.4",
+        "typescript": ">=3.1.6"
+      }
+    },
     "node_modules/react-smooth": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-2.0.0.tgz",
@@ -12200,6 +12223,14 @@
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
+      }
+    },
+    "node_modules/schema-dts": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-0.10.0.tgz",
+      "integrity": "sha512-swqBU3bFgtz/b+ldP/LEshp4clgOt130uKIgVOGLx+K3lYGUL8censjA9nQX8+jMz1oU/AeNktCIClTaNLuJzw==",
+      "peerDependencies": {
+        "typescript": ">=4.1.0"
       }
     },
     "node_modules/semver": {
@@ -13717,7 +13748,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
       "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16656,6 +16686,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.172",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.172.tgz",
+      "integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==",
       "dev": true
     },
     "@types/lossless-json": {
@@ -23462,6 +23498,12 @@
         "resize-observer-polyfill": "^1.5.1"
       }
     },
+    "react-schemaorg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-schemaorg/-/react-schemaorg-2.0.0.tgz",
+      "integrity": "sha512-UqciFKA203ewNjn0zC09uYKuJSvMD8L75L1s/cW4rc7cS64w8l7vaI3SYkuoI/nwCBkJRmOkSJedWDUZBlYZwg==",
+      "requires": {}
+    },
     "react-smooth": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-2.0.0.tgz",
@@ -23996,6 +24038,12 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
       }
+    },
+    "schema-dts": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-0.10.0.tgz",
+      "integrity": "sha512-swqBU3bFgtz/b+ldP/LEshp4clgOt130uKIgVOGLx+K3lYGUL8censjA9nQX8+jMz1oU/AeNktCIClTaNLuJzw==",
+      "requires": {}
     },
     "semver": {
       "version": "6.3.0",
@@ -25221,8 +25269,7 @@
     "typescript": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
-      "dev": true
+      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw=="
     },
     "umd": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@tailwindcss/line-clamp": "^0.2.1",
     "bignumber.js": "^9.0.1",
     "date-fns": "^2.23.0",
+    "lodash": "^4.17.21",
     "next": "11.0.1",
     "nextjs-progressbar": "^0.0.11",
     "react": "17.0.2",
@@ -44,11 +45,14 @@
     "react-icons": "^4.2.0",
     "react-number-format": "^4.6.4",
     "react-redux": "^7.2.4",
-    "recharts": "^2.0.10"
+    "react-schemaorg": "^2.0.0",
+    "recharts": "^2.0.10",
+    "schema-dts": "^0.10.0"
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.9.10",
     "@testing-library/cypress": "^8.0.0",
+    "@types/lodash": "^4.14.172",
     "@types/node": "^14.17.7",
     "@types/react": "^17.0.15",
     "autoprefixer": "^10.3.1",

--- a/src/components/commons/Breadcrumb.tsx
+++ b/src/components/commons/Breadcrumb.tsx
@@ -1,29 +1,83 @@
+import { Head } from '@components/commons/Head'
 import { Link } from '@components/commons/Link'
 import { MdChevronRight } from 'react-icons/md'
+import { jsonLdScriptProps } from 'react-schemaorg'
+import { BreadcrumbList } from 'schema-dts'
+
+const DOMAIN = 'https://defiscan.live'
 
 export interface BreadcrumbItem {
-  path: string
+  path: `/${string}`
   name: string
+  hide?: boolean
+  canonical?: boolean
 }
 
+/**
+ * Breadcrumb of the page
+ *
+ * When breadcrumb is added, https://schema.org "BreadcrumbList" will be interpolated and injected in script.
+ *
+ * @param {string} props.items.path of the Breadcrumb with `/` prefix
+ * @param {string} props.items.name of the Breadcrumb
+ * @param {boolean} [props.items.hide=false] to hide this breadcrumb from displaying, will still be added in schema.org
+ * @param {boolean} [props.items.canonical=false] set the canonical path of the page and og:url
+ */
 export function Breadcrumb (props: { items: BreadcrumbItem[] }): JSX.Element {
-  // TODO(fuxingloh): json-ld for SEO
+  const canonical = props.items.filter(value => value.canonical === true)
 
   return (
     <div className='flex items-center text-black'>
+      <Head>
+        <SchemaOrgBreadcrumbList items={props.items} />
+
+        {canonical.length > 0 ? (
+          <>
+            <link key='canonical' rel='canonical' href={`${DOMAIN}${canonical[0].path}`} />
+            <meta key='og:url' name='og:url' content={`${DOMAIN}${canonical[0].path}`} />
+          </>
+        ) : null}
+      </Head>
+
       <Link href={{ pathname: '/' }}>
         <div className='cursor-pointer hover:text-primary opacity-60 hover:opacity-100'>Scan</div>
       </Link>
-      {props.items.map(item => (
-        <div className='flex' key={item.path}>
-          <div className='px-1'>
-            <MdChevronRight className='h-6 w-6 opacity-60' />
-          </div>
-          <Link href={{ pathname: item.path }}>
-            <div className='cursor-pointer hover:text-primary opacity-60 hover:opacity-100'>{item.name}</div>
-          </Link>
-        </div>
-      ))}
+
+      {props.items
+        .filter(({ hide }) => hide === undefined || !hide)
+        .map(item => <BreadcrumbNext key={item.path} {...item} />)}
     </div>
+  )
+}
+
+function BreadcrumbNext (props: BreadcrumbItem): JSX.Element {
+  return (
+    <div className='flex' key={props.path}>
+      <div className='px-1'>
+        <MdChevronRight className='h-6 w-6 opacity-60' />
+      </div>
+      <Link href={{ pathname: props.path }}>
+        <div className='cursor-pointer hover:text-primary opacity-60 hover:opacity-100'>{props.name}</div>
+      </Link>
+    </div>
+  )
+}
+
+function SchemaOrgBreadcrumbList (props: { items: BreadcrumbItem[] }): JSX.Element {
+  return (
+    <script
+      {...jsonLdScriptProps<BreadcrumbList>({
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        itemListElement: props.items.map((item, index) => ({
+          '@type': 'ListItem',
+          position: index + 1,
+          item: {
+            '@id': `${DOMAIN}${item.path}`,
+            name: item.name
+          }
+        }))
+      })}
+    />
   )
 }

--- a/src/components/commons/Breadcrumb.tsx
+++ b/src/components/commons/Breadcrumb.tsx
@@ -7,7 +7,7 @@ import { BreadcrumbList } from 'schema-dts'
 const DOMAIN = 'https://defiscan.live'
 
 export interface BreadcrumbItem {
-  path: `/${string}`
+  path: string
   name: string
   hide?: boolean
   canonical?: boolean

--- a/src/components/commons/Head.tsx
+++ b/src/components/commons/Head.tsx
@@ -1,0 +1,40 @@
+/* eslint-disable no-restricted-imports */
+import { truncate } from 'lodash'
+import NextHead from 'next/head'
+import { PropsWithChildren } from 'react'
+
+interface HeadProps {
+  title?: string
+  description?: string
+}
+
+/**
+ * Overrides the default next/head to provide ability insert consistent open graph tags.
+ *
+ * @param {string} [props.title] added to <title> and <meta og:title> with " • DeFi Scan – ..." postfix
+ * @param {string} [props.description] added to <meta og:description> and <meta :description>
+ */
+export function Head (props: PropsWithChildren<HeadProps>): JSX.Element {
+  const title = props.title !== undefined ? `${props.title} • DeFi Scan – Native Decentralized Finance for Bitcoin` : undefined
+  const description = truncate(props.description, { length: 200 })
+
+  return (
+    <NextHead>
+      {title !== undefined ? (
+        <>
+          <title key='title'>{title}</title>
+          <meta key='og:title' name='og:title' content={title} />
+        </>
+      ) : null}
+
+      {description !== undefined ? (
+        <>
+          <meta key='description' name='description' content={description} />
+          <meta key='og:description' name='og:description' content={description} />
+        </>
+      ) : null}
+
+      {props.children}
+    </NextHead>
+  )
+}

--- a/src/layouts/Default.tsx
+++ b/src/layouts/Default.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-imports */
 import Head from 'next/head'
 import { PropsWithChildren } from 'react'
 import { Provider } from 'react-redux'
@@ -8,7 +9,7 @@ import { NetworkProvider } from './contexts/NetworkContext'
 import { PlaygroundProvider } from './contexts/PlaygroundContext'
 import { WhaleProvider } from './contexts/WhaleContext'
 
-const title = 'DeFi Scan'
+const title = 'DeFi Scan – Native Decentralized Finance for Bitcoin'
 const description = 'DeFi Blockchain, enabling decentralized finance with Bitcoin-grade security, strength and immutability. A blockchain dedicated to fast, intelligent and transparent financial services, accessible by everyone.'
 
 /**
@@ -24,7 +25,7 @@ export function Default (props: PropsWithChildren<any>): JSX.Element | null {
       <Head>
         <meta charSet='UTF-8' />
 
-        <title>{title}</title>
+        <title key='title'>{title}</title>
         <meta key='description' name='description' content={description} />
         <meta key='robots' name='robots' content='follow,index' />
         <meta key='viewport' name='viewport' content='user-scalable=no, width=device-width, initial-scale=1' />

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,4 +1,4 @@
-import Head from 'next/head'
+import { Head } from '@components/commons/Head'
 
 export default function NotFound (): JSX.Element {
   return (

--- a/src/pages/prices/[symbol].tsx
+++ b/src/pages/prices/[symbol].tsx
@@ -1,11 +1,11 @@
 import { Breadcrumb } from '@components/commons/Breadcrumb'
+import { Head } from '@components/commons/Head'
 import { PriceGraph } from '@components/prices/PriceGraph'
 import { PriceOracleTable } from '@components/prices/PriceOracleTable'
 import { PriceTickerDetail } from '@components/prices/PriceTickerDetail'
 import { getWhaleApiClient } from '@contexts'
 import { PriceOracle, PriceTicker } from '@defichain/whale-api-client/dist/api/prices'
 import { GetServerSidePropsContext, GetServerSidePropsResult, InferGetServerSidePropsType } from 'next'
-import Head from 'next/head'
 import { getPriceCopy, PriceCopy } from '../../cms/prices'
 
 interface PricesPageProps {
@@ -19,14 +19,12 @@ export default function SymbolPage (props: InferGetServerSidePropsType<typeof ge
 
   return (
     <div className='container mx-auto px-4 pt-12 pb-20'>
-      <Head>
-        <title>{token}/{currency} – DeFi Scan</title>
-        <meta key='og:title' name='og:title' content={`${token}/${currency} – DeFi Scan`} />
-        <meta key='description' name='description' content={copy?.description} />
-        <meta key='og:description' name='og:description' content={copy?.description} />
-      </Head>
-
-      <Breadcrumb items={[{ path: '/prices', name: 'Prices' }]} />
+      <Head title={`${token}/${currency}`} description={copy?.description} />
+      <Breadcrumb items={[
+        { path: '/prices', name: 'Prices' },
+        { path: `/prices/${token}-${currency}`, name: `${token}/${currency}`, hide: true, canonical: true }
+      ]}
+      />
 
       <div className='flex flex-wrap -mx-6'>
         <div className='w-full lg:w-1/3 px-6'>

--- a/src/pages/prices/index.tsx
+++ b/src/pages/prices/index.tsx
@@ -1,8 +1,8 @@
+import { Head } from '@components/commons/Head'
 import { PriceFeed } from '@components/prices/PriceFeed'
 import { getWhaleApiClient } from '@contexts'
 import { prices } from '@defichain/whale-api-client'
 import { GetServerSidePropsContext, GetServerSidePropsResult, InferGetServerSidePropsType } from 'next'
-import Head from 'next/head'
 import Image from 'next/image'
 import { useState } from 'react'
 import { ORACLES } from '../../cms/oracles'
@@ -20,9 +20,7 @@ export default function PricesPage (props: InferGetServerSidePropsType<typeof ge
 
   return (
     <div className='container mx-auto px-4 pt-12 pb-20'>
-      <Head>
-        <title>Prices – DeFi Scan</title>
-      </Head>
+      <Head title='Prices' />
 
       <div>
         <h1 className='text-2xl font-semibold'>


### PR DESCRIPTION
#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Breadcrumb.tsx will now interpolate SEO metadata: 
- https://schema.org BreadcrumbList
- canonical url
- og url

Head.tsx will now override default next/head implementation to allow consistent title and description open graph tags
- Also updated `.idea` configs to ignore title in `<Head/>`

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes part of #39
