### PR TITLE
Redux Store is now cached on client side on SSR it will be hydrated over

### DIFF
--- a/src/layouts/Default.tsx
+++ b/src/layouts/Default.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable no-restricted-imports */
 import { NetworkProvider } from '@contexts/NetworkContext'
 import { PlaygroundProvider } from '@contexts/PlaygroundContext'
+import { StoreProvider } from '@contexts/StoreProvider'
 import { WhaleProvider } from '@contexts/WhaleContext'
 import { StatsProvider } from '@store/stats'
 import Head from 'next/head'
 import { PropsWithChildren } from 'react'
-import { Provider as StoreProvider } from 'react-redux'
-import { createStore } from '../store'
+import { ScanAppProps } from '../pages/_app'
 import { Footer } from './components/Footer'
 import { Header } from './components/Header'
 
@@ -20,9 +20,7 @@ const description = 'DeFi Blockchain, enabling decentralized finance with Bitcoi
  * Followed by <PlaygroundProvider> to automatically swatch between local and remote playground for debug environment.
  * Finally with <WhaleProvider> to provide WhaleContext for accessing of WhaleAPI and WhaleRPC.
  */
-export function Default (props: PropsWithChildren<any>): JSX.Element | null {
-  const store = createStore()
-
+export function Default (props: PropsWithChildren<ScanAppProps>): JSX.Element | null {
   return (
     <div className='flex flex-col min-h-screen'>
       <Head>
@@ -46,7 +44,7 @@ export function Default (props: PropsWithChildren<any>): JSX.Element | null {
       <NetworkProvider>
         <PlaygroundProvider>
           <WhaleProvider>
-            <StoreProvider store={store}>
+            <StoreProvider state={props.initialReduxState}>
               <StatsProvider>
                 <Header />
 

--- a/src/layouts/contexts/StoreProvider.tsx
+++ b/src/layouts/contexts/StoreProvider.tsx
@@ -1,0 +1,22 @@
+import { initializeStore, RootState, RootStore } from '@store/index'
+import { PropsWithChildren } from 'react'
+import { Provider } from 'react-redux'
+
+let store: RootStore | undefined
+
+interface StoreProviderProps {
+  state: RootState
+}
+
+/**
+ * StoreProvider prevent Store from reloading by hydrating
+ */
+export function StoreProvider (props: PropsWithChildren<StoreProviderProps>): JSX.Element {
+  store = store ?? initializeStore(props.state)
+
+  return (
+    <Provider store={store}>
+      {props.children}
+    </Provider>
+  )
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,23 +1,27 @@
-import App, { AppContext } from 'next/app'
+import { initializeStore, RootState } from '@store/index'
+import { GetServerSidePropsResult } from 'next'
 import NextNProgress from 'nextjs-progressbar'
 import { Default } from '../layouts/Default'
 import '../styles/globals.css'
 
-function ScanApp ({ Component, pageProps }): JSX.Element {
+export interface ScanAppProps {
+  initialReduxState: RootState
+}
+
+export default function ScanApp ({ Component, pageProps }): JSX.Element {
   return (
-    <Default>
+    <Default {...pageProps}>
       <NextNProgress color='#ff00af' height={2} />
       <Component {...pageProps} />
     </Default>
   )
 }
 
-/**
- * To load SSR for hydrating
- */
-ScanApp.getInitialProps = async (ctx: AppContext) => {
-  const appProps = await App.getInitialProps(ctx)
-  return { ...appProps }
+export function getServerSideProps (): GetServerSidePropsResult<ScanAppProps> {
+  const store = initializeStore()
+  return {
+    props: {
+      initialReduxState: store.getState()
+    }
+  }
 }
-
-export default ScanApp

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -10,12 +10,14 @@ import { stats } from '@store/stats'
  *
  * Non-global state should be managed independently within their own React Component/Page.
  */
-export function createStore () {
+export function initializeStore (preloadedState?: any) {
   return configureStore({
     reducer: {
       stats: stats.reducer
-    }
+    },
+    preloadedState: preloadedState
   })
 }
 
-export type RootState = ReturnType<ReturnType<typeof createStore>['getState']>
+export type RootStore = ReturnType<typeof initializeStore>
+export type RootState = ReturnType<RootStore['getState']>

--- a/src/store/stats.tsx
+++ b/src/store/stats.tsx
@@ -62,7 +62,7 @@ export function StatsProvider (props: PropsWithChildren<{}>): JSX.Element {
     fetch()
     const intervalId = setInterval(fetch, interval)
     return () => clearInterval(intervalId)
-  }, [api, interval, dispatch])
+  }, [])
 
   return <>{props.children}</>
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

Redux Store is now cached on the client side, on SSR it will be hydrated over. For SPA page load, it will not reload the store anymore.