### PR TITLE
Added CursorPagination for LSM index querying

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
   ],
   "ignorePatterns": ["*.json"],
   "rules": {
+    "@typescript-eslint/no-non-null-assertion": "off",
     "func-style": [2, "declaration"],
     "no-void": "off",
     "import/no-default-export": "error",

--- a/src/components/commons/CursorPagination.tsx
+++ b/src/components/commons/CursorPagination.tsx
@@ -1,0 +1,153 @@
+import { Link } from '@components/commons/Link'
+import { ApiPagedResponse } from '@defichain/whale-api-client'
+import { last, takeRight } from 'lodash'
+import { GetServerSidePropsContext } from 'next'
+import { PropsWithChildren } from 'react'
+import { MdNavigateBefore, MdNavigateNext } from 'react-icons/md'
+
+export interface CursorPage {
+  n: number
+  active: boolean
+  cursors: string[]
+}
+
+interface CursorPaginationProps {
+  className?: string
+  pages: CursorPage[]
+  path: `/${string}`
+}
+
+/**
+ * To get next from Context
+ * @example const next = CursorPagination.getNext(GetServerSidePropsContext)
+ *
+ * To get pages available from Context and next ApiPagedResponse
+ * @example const pages = CursorPagination.getPages(GetServerSidePropsContext, ApiPagedResponse)
+ *
+ * To render the pagination
+ * @example <CursorPaginationProps pages={pages} path='/...' />
+ *
+ * @param {CursorPaginationProps} props
+ */
+export function CursorPagination (props: CursorPaginationProps): JSX.Element {
+  const pages = takeRight(props.pages, 3)
+  const activeIndex = pages.findIndex(value => value.active)
+  const prev = pages[activeIndex - 1]
+  const next = pages[activeIndex + 1]
+
+  return (
+    <div className={props.className}>
+      <div className='flex space-x-2'>
+        <NavigateButton path={props.path} {...prev}>
+          <MdNavigateBefore className='h-6 w-6' />
+        </NavigateButton>
+        {pages.map(page => (
+          <NumberButton key={page.n} path={props.path} {...page} />
+        ))}
+        <NavigateButton path={props.path} {...next}>
+          <MdNavigateNext className='h-6 w-6' />
+        </NavigateButton>
+      </div>
+    </div>
+  )
+}
+
+function NumberButton (props: CursorPage & { path: string }): JSX.Element {
+  if (props.active) {
+    return (
+      <div className='bg-gray-50 rounded border border-primary text-primary cursor-not-allowed'>
+        <div className='h-11 w-11 flex items-center justify-center'>
+          <span className='font-medium'>{props.n}</span>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <Link href={{ pathname: props.path, query: getQueryFromCursors(props.cursors) }}>
+      <div className='bg-gray-50 rounded border border-gray-200 hover:border-primary hover:text-primary cursor-pointer'>
+        <div className='h-11 w-11 flex items-center justify-center'>
+          <span className='font-medium'>{props.n}</span>
+        </div>
+      </div>
+    </Link>
+  )
+}
+
+function NavigateButton (props: PropsWithChildren<{ path: string, cursors: string[] | undefined }>): JSX.Element {
+  if (props.cursors === undefined) {
+    return (
+      <div className='bg-gray-50 rounded border border-gray-200 text-gray-600 opacity-40 cursor-not-allowed'>
+        <div className='h-11 w-11 flex items-center justify-center'>
+          {props.children}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <Link href={{ pathname: props.path, query: getQueryFromCursors(props.cursors) }}>
+      <div
+        className='bg-gray-50 rounded border border-gray-200 text-gray-600 hover:border-primary hover:text-primary cursor-pointer'
+      >
+        <div className='h-11 w-11 flex items-center justify-center'>
+          {props.children}
+        </div>
+      </div>
+    </Link>
+  )
+}
+
+function getQueryFromCursors (cursors: string[]): Record<string, string> {
+  if (cursors.length === 0) {
+    return {}
+  }
+
+  return {
+    cursors: cursors.join(',')
+  }
+}
+
+function getCursorsFromContext (context: GetServerSidePropsContext): string[] {
+  if (context.query.cursors !== undefined) {
+    return (context.query.cursors as string).split(',')
+  }
+  return []
+}
+
+/**
+ * @param {GetServerSidePropsContext} context to get the last next
+ */
+CursorPagination.getNext = (context: GetServerSidePropsContext): string | undefined => {
+  return last(getCursorsFromContext(context))
+}
+
+/**
+ * @param {GetServerSidePropsContext} context
+ * @param {ApiPagedResponse} paged
+ */
+CursorPagination.getPages = (context: GetServerSidePropsContext, paged: ApiPagedResponse<any>): CursorPage[] => {
+  const pages: CursorPage[] = [
+    { n: 1, active: false, cursors: [] }
+  ]
+
+  for (const cursor of getCursorsFromContext(context)) {
+    pages.push({
+      n: pages.length + 1,
+      active: false,
+      cursors: [...last(pages)!.cursors, cursor]
+    })
+  }
+
+  pages[pages.length - 1].active = true
+
+  if (paged.nextToken !== undefined) {
+    pages.push({
+      n: pages.length + 1,
+      active: false,
+      cursors: [...last(pages)!.cursors, paged.nextToken]
+    })
+  }
+
+  return pages
+}

--- a/src/pages/dex/index.tsx
+++ b/src/pages/dex/index.tsx
@@ -171,7 +171,7 @@ function PoolPairRow ({ data }: { data: PoolPairData }): JSX.Element {
 
 export async function getServerSideProps (context: GetServerSidePropsContext): Promise<GetServerSidePropsResult<DexPageProps>> {
   const next = CursorPagination.getNext(context)
-  const items = await getWhaleApiClient(context).poolpairs.list(2, next)
+  const items = await getWhaleApiClient(context).poolpairs.list(30, next)
   return {
     props: {
       poolPairs: {

--- a/src/pages/dex/index.tsx
+++ b/src/pages/dex/index.tsx
@@ -1,4 +1,5 @@
 import { AdaptiveTable } from '@components/commons/AdaptiveTable'
+import { CursorPage, CursorPagination } from '@components/commons/CursorPagination'
 import { Head } from '@components/commons/Head'
 import { HoverPopover } from '@components/commons/popover/HoverPopover'
 import { getTokenIcon } from '@components/icons/tokens'
@@ -8,7 +9,6 @@ import { PoolPairData } from '@defichain/whale-api-client/dist/api/poolpairs'
 import { RootState } from '@store/index'
 import BigNumber from 'bignumber.js'
 import { GetServerSidePropsContext, GetServerSidePropsResult, InferGetServerSidePropsType } from 'next'
-import { useState } from 'react'
 import { IoAlertCircle } from 'react-icons/io5'
 import NumberFormat from 'react-number-format'
 import { useSelector } from 'react-redux'
@@ -16,14 +16,12 @@ import { useSelector } from 'react-redux'
 interface DexPageProps {
   poolPairs: {
     items: poolpairs.PoolPairData[]
-    nextToken: string | null
+    pages: CursorPage[]
   }
 }
 
 export default function DexPage ({ poolPairs }: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element {
   const tvl = useSelector((state: RootState) => state.stats.tvl.dex)
-  const [items] = useState(poolPairs.items)
-  // const [nextToken, setNextToken] = useState(poolPairs.nextToken)
 
   return (
     <div className='container mx-auto px-4 pt-12 pb-20'>
@@ -69,10 +67,14 @@ export default function DexPage ({ poolPairs }: InferGetServerSidePropsType<type
             </AdaptiveTable.Head>
           </AdaptiveTable.Header>
 
-          {items.map((data) => (
+          {poolPairs.items.map((data) => (
             <PoolPairRow key={data.id} data={data} />
           ))}
         </AdaptiveTable>
+
+        <div className='flex justify-end mt-8'>
+          <CursorPagination pages={poolPairs.pages} path='/dex' />
+        </div>
       </div>
     </div>
   )
@@ -168,12 +170,13 @@ function PoolPairRow ({ data }: { data: PoolPairData }): JSX.Element {
 }
 
 export async function getServerSideProps (context: GetServerSidePropsContext): Promise<GetServerSidePropsResult<DexPageProps>> {
-  const items = await getWhaleApiClient(context).poolpairs.list()
+  const next = CursorPagination.getNext(context)
+  const items = await getWhaleApiClient(context).poolpairs.list(2, next)
   return {
     props: {
       poolPairs: {
         items: items,
-        nextToken: items.nextToken ?? null
+        pages: CursorPagination.getPages(context, items)
       }
     }
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Added `CursorPagination.tsx` to mock pagination with LSM indexes.
```ts
/**
 * To get `next` from Context
 * @example const next = CursorPagination.getNext(GetServerSidePropsContext)
 *
 * To get pages available from Context and next ApiPagedResponse
 * @example const pages = CursorPagination.getPages(GetServerSidePropsContext, ApiPagedResponse)
 *
 * To render the pagination
 * @example <CursorPaginationProps pages={pages} path='/...' />
 *
 * @param {CursorPaginationProps} props
 */
```

Implementation examples:
```ts
export async function getServerSideProps (context: GetServerSidePropsContext): Promise<GetServerSidePropsResult<DexPageProps>> {
  const next = CursorPagination.getNext(context)
  const items = await getWhaleApiClient(context).poolpairs.list(2, next)
  return {
    props: {
      items: items,
      pages: CursorPagination.getPages(context, items)
    }
  }
}
```

```html
<CursorPagination pages={poolPairs.pages} path='/dex' />
```

> Implemented with an example on `/dex` with size = 2. Once approved, I will remove the size=2 on `/dex`.
