### PR TITLE
update lint-staged to only run on `src/*`

### DIFF
--- a/cypress/integration/layouts/header.spec.ts
+++ b/cypress/integration/layouts/header.spec.ts
@@ -3,7 +3,7 @@ describe('header', () => {
     cy.visit('/?network=MainNet')
   })
 
-  it('should contain block count', function () {
+  it('should not contain empty block count', function () {
     cy.get('header ul li:nth-child(1)').should('not.have.text', 'Blocks: ...')
   })
 })

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
     "typescript": "4.3.2"
   },
   "lint-staged": {
-    "*.{ts,tsx,js}": "npm run lint"
+    "./src/**/*.{ts,tsx,js}": "npm run lint"
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

Updated lint-staged to only run on `src/*` so that it doesn't pick up on cypress tests.