### PR TITLE
Refactor <Link> children to use <a> to take advantage of native linking

### DIFF
--- a/src/components/commons/Breadcrumb.tsx
+++ b/src/components/commons/Breadcrumb.tsx
@@ -40,7 +40,7 @@ export function Breadcrumb (props: { items: BreadcrumbItem[] }): JSX.Element {
       </Head>
 
       <Link href={{ pathname: '/' }}>
-        <div className='cursor-pointer hover:text-primary opacity-60 hover:opacity-100'>Scan</div>
+        <a className='cursor-pointer hover:text-primary opacity-60 hover:opacity-100'>Scan</a>
       </Link>
 
       {props.items
@@ -57,7 +57,7 @@ function BreadcrumbNext (props: BreadcrumbItem): JSX.Element {
         <MdChevronRight className='h-6 w-6 opacity-60' />
       </div>
       <Link href={{ pathname: props.path }}>
-        <div className='cursor-pointer hover:text-primary opacity-60 hover:opacity-100'>{props.name}</div>
+        <a className='cursor-pointer hover:text-primary opacity-60 hover:opacity-100'>{props.name}</a>
       </Link>
     </div>
   )

--- a/src/components/commons/CursorPagination.tsx
+++ b/src/components/commons/CursorPagination.tsx
@@ -65,11 +65,11 @@ function NumberButton (props: CursorPage & { path: string }): JSX.Element {
 
   return (
     <Link href={{ pathname: props.path, query: getQueryFromCursors(props.cursors) }}>
-      <div className='bg-gray-50 rounded border border-gray-200 hover:border-primary hover:text-primary cursor-pointer'>
+      <a className='bg-gray-50 rounded border border-gray-200 hover:border-primary hover:text-primary cursor-pointer'>
         <div className='h-11 w-11 flex items-center justify-center'>
           <span className='font-medium'>{props.n}</span>
         </div>
-      </div>
+      </a>
     </Link>
   )
 }
@@ -87,13 +87,13 @@ function NavigateButton (props: PropsWithChildren<{ path: string, cursors: strin
 
   return (
     <Link href={{ pathname: props.path, query: getQueryFromCursors(props.cursors) }}>
-      <div
+      <a
         className='bg-gray-50 rounded border border-gray-200 text-gray-600 hover:border-primary hover:text-primary cursor-pointer'
       >
         <div className='h-11 w-11 flex items-center justify-center'>
           {props.children}
         </div>
-      </div>
+      </a>
     </Link>
   )
 }

--- a/src/components/commons/Link.tsx
+++ b/src/components/commons/Link.tsx
@@ -34,7 +34,7 @@ export function Link (props: PropsWithChildren<LinkProps>): JSX.Element {
   }
 
   return (
-    <NextLink {...props}>
+    <NextLink passHref {...props}>
       {props.children}
     </NextLink>
   )

--- a/src/components/prices/PriceFeed.tsx
+++ b/src/components/prices/PriceFeed.tsx
@@ -19,7 +19,7 @@ export function PriceFeed (props: PriceFeedProps): JSX.Element {
 
   return (
     <Link href={{ pathname: `/prices/${id}` }}>
-      <div className='w-full md:w-1/2 lg:w-1/3 xl:w-1/4 p-4'>
+      <a className='w-full md:w-1/2 lg:w-1/3 xl:w-1/4 p-4'>
         <div className='bg-gray-50 rounded p-6 cursor-pointer'>
           <div className='flex'>
             {copy !== undefined ? (
@@ -72,7 +72,7 @@ export function PriceFeed (props: PriceFeedProps): JSX.Element {
             </button>
           </div>
         </div>
-      </div>
+      </a>
     </Link>
   )
 }

--- a/src/layouts/components/Footer.tsx
+++ b/src/layouts/components/Footer.tsx
@@ -7,10 +7,10 @@ export function Footer (): JSX.Element {
   return (
     <footer className='mt-12 bg-gray-50'>
       <div className='container mx-auto px-4 py-12'>
-        <Link href={{ pathname: '/' }} passHref>
-          <div className='cursor-pointer'>
+        <Link href={{ pathname: '/' }}>
+          <a className='cursor-pointer'>
             <DeFiChainLogo className='w-28 h-full' />
-          </div>
+          </a>
         </Link>
 
         <div className='mt-4 flex flex-wrap'>

--- a/src/layouts/components/Header.tsx
+++ b/src/layouts/components/Header.tsx
@@ -39,10 +39,10 @@ export function Header (): JSX.Element {
           <div className='flex items-center justify-between'>
             <div className='flex'>
               <Link href={{ pathname: '/' }} passHref>
-                <div className='flex items-center cursor-pointer hover:text-primary'>
+                <a className='flex items-center cursor-pointer hover:text-primary'>
                   <DeFiChainLogo className='w-16 h-full' />
                   <h6 className='ml-3 text-xl font-medium'>Scan</h6>
-                </div>
+                </a>
               </Link>
 
               <div className='hidden md:flex flex-wrap'>
@@ -176,11 +176,11 @@ function HeaderNetworkMenu (): JSX.Element {
 function HeaderLink (props: { text: string, pathname: string, className: string }): JSX.Element {
   return (
     <Link href={{ pathname: props.pathname }}>
-      <div className={props.className}>
+      <a className={props.className}>
         <div className='p-2 text-lg hover:text-primary cursor-pointer'>
           {props.text}
         </div>
-      </div>
+      </a>
     </Link>
   )
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

All `<Link>` children should include `<a>` to take advantage to browser native linking.
