### PR TITLE
ci.yml and ci-e2e.yml to always run on push main and '0 1 * * *'

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 1 * * *'
-    - cron: '0 9 * * *'
-
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -13,7 +13,7 @@ jobs:
   main:
     name: Cypress
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       fail-fast: false # https://github.com/cypress-io/github-action/issues/48
       matrix:


### PR DESCRIPTION



<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:
ci.yml and ci-e2e.yml to always run on push main and '0 1 * * *' due to code coverage
