### PR TITLE
`/tokens` page refactor

### DIFF
--- a/cypress/integration/pages/tokens/tokens.spec.ts
+++ b/cypress/integration/pages/tokens/tokens.spec.ts
@@ -5,36 +5,36 @@ describe('Tokens Page', () => {
 
   it('should render header information', function () {
     cy.get('h1[data-testid="page_title"]').should('have.text', 'Tokens')
-    cy.get('div[data-testid="adaptive_table"] div[data-testid="adaptive_header"]  > div:nth-child(1)').should('have.text', 'TOKEN NAME')
-    cy.get('div[data-testid="adaptive_table"] div[data-testid="adaptive_header"]  > div:nth-child(2)').should('have.text', 'SYMBOL')
-    cy.get('div[data-testid="adaptive_table"] div[data-testid="adaptive_header"]  > div:nth-child(3)').should('have.text', 'CATEGORY')
-    cy.get('div[data-testid="adaptive_table"] div[data-testid="adaptive_header"]  > div:nth-child(4)').should('have.text', 'MINTED')
+    cy.get('div[data-testid="AdaptiveTable"] div[data-testid="AdaptiveTable.Header"] > div:nth-child(1)').should('have.text', 'TOKEN NAME')
+    cy.get('div[data-testid="AdaptiveTable"] div[data-testid="AdaptiveTable.Header"] > div:nth-child(2)').should('have.text', 'SYMBOL')
+    cy.get('div[data-testid="AdaptiveTable"] div[data-testid="AdaptiveTable.Header"] > div:nth-child(3)').should('have.text', 'CATEGORY')
+    cy.get('div[data-testid="AdaptiveTable"] div[data-testid="AdaptiveTable.Header"] > div:nth-child(4)').should('have.text', 'MINTED')
   })
 
   it('should render tokens information', function () {
-    cy.get('div[data-testid="adaptive_table"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should('have.text', 'Tether USD')
-    cy.get('div[data-testid="adaptive_table"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(2) > div:nth-child(2)').should('have.text', 'USDT')
-    cy.get('div[data-testid="adaptive_table"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(2)').should('have.text', 'DAT')
-    cy.get('div[data-testid="adaptive_table"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(4) > div:nth-child(2)').should('exist')
+    cy.get('div[data-testid="AdaptiveTable"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should('have.text', 'Tether USD')
+    cy.get('div[data-testid="AdaptiveTable"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(2) > div:nth-child(2)').should('have.text', 'USDT')
+    cy.get('div[data-testid="AdaptiveTable"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(2)').should('have.text', 'DAT')
+    cy.get('div[data-testid="AdaptiveTable"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(4) > div:nth-child(2)').should('exist')
   })
 
   it('should render next list when next button is clicked', function () {
-    const firstPage = cy.get('[data-testid="adaptive_table"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should(($elem) => $elem.text())
+    const firstPage = cy.get('[data-testid="AdaptiveTable"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should(($elem) => $elem.text())
 
-    cy.get('a[data-testid="navigate_button_next"]').click().wait(200)
-    cy.get('div[data-testid="adaptive_table"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should(($elem) => {
+    cy.get('a[data-testid="NavigateButton.Next"]').click().wait(200)
+    cy.get('div[data-testid="AdaptiveTable"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should(($elem) => {
       expect($elem.text()).not.equals(firstPage)
     })
   })
 
   it('should render previous list when previous button is clicked', function () {
-    cy.get('a[data-testid="navigate_button_next"]').click().wait(200)
+    cy.get('a[data-testid="NavigateButton.Next"]').click().wait(200)
 
-    const nextPage = cy.get('[data-testid="adaptive_table"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should(($elem) => $elem.text())
+    const nextPage = cy.get('[data-testid="AdaptiveTable"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should(($elem) => $elem.text())
 
-    cy.get('a[data-testid="navigate_button_prev"]').click().wait(200)
+    cy.get('a[data-testid="NavigateButton.Prev"]').click().wait(200)
 
-    cy.get('div[data-testid="adaptive_table"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should(($elem) => {
+    cy.get('div[data-testid="AdaptiveTable"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should(($elem) => {
       expect($elem.text()).not.equals(nextPage)
     })
   })

--- a/cypress/integration/pages/tokens/tokens.spec.ts
+++ b/cypress/integration/pages/tokens/tokens.spec.ts
@@ -1,41 +1,51 @@
-describe('Tokens Page', () => {
-  beforeEach(function () {
-    cy.visit('/tokens/?network=MainNet')
+context('/tokens on desktop', () => {
+  before(() => {
+    cy.visit('/tokens?network=MainNet')
   })
 
-  it('should render header information', function () {
-    cy.get('h1[data-testid="page_title"]').should('have.text', 'Tokens')
-    cy.get('div[data-testid="AdaptiveTable"] div[data-testid="AdaptiveTable.Header"] > div:nth-child(1)').should('have.text', 'TOKEN NAME')
-    cy.get('div[data-testid="AdaptiveTable"] div[data-testid="AdaptiveTable.Header"] > div:nth-child(2)').should('have.text', 'SYMBOL')
-    cy.get('div[data-testid="AdaptiveTable"] div[data-testid="AdaptiveTable.Header"] > div:nth-child(3)').should('have.text', 'CATEGORY')
-    cy.get('div[data-testid="AdaptiveTable"] div[data-testid="AdaptiveTable.Header"] > div:nth-child(4)').should('have.text', 'MINTED')
+  it('should have heading', () => {
+    cy.get('h1').should('have.text', 'Tokens')
   })
 
-  it('should render tokens information', function () {
-    cy.get('div[data-testid="AdaptiveTable"] div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should('have.text', 'Tether USD')
-    cy.get('div[data-testid="AdaptiveTable"] div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(2) > div:nth-child(2)').should('have.text', 'USDT')
-    cy.get('div[data-testid="AdaptiveTable"] div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(2)').should('have.text', 'DAT')
-    cy.get('div[data-testid="AdaptiveTable"] div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(4) > div:nth-child(2)').should('exist')
-  })
-
-  it('should render next list when next button is clicked', function () {
-    const firstPage = cy.get('[data-testid="AdaptiveTable"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should(($elem) => $elem.text())
-
-    cy.get('a[data-testid="NavigateButton.Next"]').click().wait(200)
-    cy.get('div[data-testid="AdaptiveTable"] div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should(($elem) => {
-      expect($elem.text()).not.equals(firstPage)
+  it('should have AdaptiveTable header information', function () {
+    cy.findByTestId('AdaptiveTable.Header').then(ele => {
+      cy.wrap(ele).findByText('TOKEN').should('be.visible')
+      cy.wrap(ele).findByText('NAME').should('be.visible')
+      cy.wrap(ele).findByText('CATEGORY').should('be.visible')
+      cy.wrap(ele).findByText('MINTED').should('be.visible')
     })
   })
 
-  it('should render previous list when previous button is clicked', function () {
-    cy.get('a[data-testid="NavigateButton.Next"]').click().wait(200)
-
-    const nextPage = cy.get('[data-testid="AdaptiveTable"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should(($elem) => $elem.text())
-
-    cy.get('a[data-testid="NavigateButton.Prev"]').click().wait(200)
-
-    cy.get('div[data-testid="AdaptiveTable"] div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should(($elem) => {
-      expect($elem.text()).not.equals(nextPage)
+  it('should have Tether in AdaptiveTable', function () {
+    cy.findAllByTestId('AdaptiveTable.Row').eq(3).then(ele => {
+      cy.wrap(ele).findByText('USDT').should('be.visible')
+      cy.wrap(ele).findByText('Tether USD').should('be.visible')
+      cy.wrap(ele).findByText('DAT').should('be.visible')
     })
   })
+
+  it('should CursorPagination.Next and CursorPagination.Prev', function () {
+    const pages: Record<number, string> = {}
+
+    cy.findByTestId('AdaptiveTable').should((ele) => {
+      pages[0] = ele.text()
+    })
+
+    cy.findByTestId('CursorPagination.Next').click()
+    cy.findByTestId('AdaptiveTable').should((ele) => {
+      pages[1] = ele.text()
+
+      expect(pages[1]).not.equals(pages[0])
+    })
+
+    cy.findByTestId('CursorPagination.Prev').click()
+    cy.findByTestId('AdaptiveTable').should((ele) => {
+      expect(ele.text()).equals(pages[0])
+      expect(ele.text()).not.equals(pages[1])
+    })
+  })
+})
+
+context('/tokens on mobile', () => {
+  // TODO(suraj):
 })

--- a/cypress/integration/pages/tokens/tokens.spec.ts
+++ b/cypress/integration/pages/tokens/tokens.spec.ts
@@ -12,17 +12,17 @@ describe('Tokens Page', () => {
   })
 
   it('should render tokens information', function () {
-    cy.get('div[data-testid="AdaptiveTable"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should('have.text', 'Tether USD')
-    cy.get('div[data-testid="AdaptiveTable"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(2) > div:nth-child(2)').should('have.text', 'USDT')
-    cy.get('div[data-testid="AdaptiveTable"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(2)').should('have.text', 'DAT')
-    cy.get('div[data-testid="AdaptiveTable"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(4) > div:nth-child(2)').should('exist')
+    cy.get('div[data-testid="AdaptiveTable"] div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should('have.text', 'Tether USD')
+    cy.get('div[data-testid="AdaptiveTable"] div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(2) > div:nth-child(2)').should('have.text', 'USDT')
+    cy.get('div[data-testid="AdaptiveTable"] div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(2)').should('have.text', 'DAT')
+    cy.get('div[data-testid="AdaptiveTable"] div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(4) > div:nth-child(2)').should('exist')
   })
 
   it('should render next list when next button is clicked', function () {
     const firstPage = cy.get('[data-testid="AdaptiveTable"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should(($elem) => $elem.text())
 
     cy.get('a[data-testid="NavigateButton.Next"]').click().wait(200)
-    cy.get('div[data-testid="AdaptiveTable"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should(($elem) => {
+    cy.get('div[data-testid="AdaptiveTable"] div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should(($elem) => {
       expect($elem.text()).not.equals(firstPage)
     })
   })
@@ -34,7 +34,7 @@ describe('Tokens Page', () => {
 
     cy.get('a[data-testid="NavigateButton.Prev"]').click().wait(200)
 
-    cy.get('div[data-testid="AdaptiveTable"]  div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should(($elem) => {
+    cy.get('div[data-testid="AdaptiveTable"] div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(2)').should(($elem) => {
       expect($elem.text()).not.equals(nextPage)
     })
   })

--- a/src/components/commons/AdaptiveTable.tsx
+++ b/src/components/commons/AdaptiveTable.tsx
@@ -2,7 +2,10 @@ import { PropsWithChildren } from 'react'
 
 export function AdaptiveTable (props: PropsWithChildren<{ className?: string }>): JSX.Element {
   return (
-    <div data-testid='adaptive_table' className={`lg:border lg:rounded-lg overflow-hidden w-full ${props.className ?? ''}`}>
+    <div
+      data-testid='AdaptiveTable'
+      className={`lg:border lg:rounded-lg overflow-hidden w-full ${props.className ?? ''}`}
+    >
       <div className='table w-full border-collapse -mt-6 lg:mt-0'>
         <div className='table-row-group space-y-6'>
           {props.children}
@@ -14,7 +17,10 @@ export function AdaptiveTable (props: PropsWithChildren<{ className?: string }>)
 
 function Header (props: PropsWithChildren<{ className?: string }>): JSX.Element {
   return (
-    <div data-testid='adaptive_header' className={`hidden lg:table-row border-gray-200 bg-gray-50 ${props.className ?? ''}`}>
+    <div
+      data-testid='AdaptiveTable.Header'
+      className={`hidden lg:table-row border-gray-200 bg-gray-50 ${props.className ?? ''}`}
+    >
       {props.children}
     </div>
   )
@@ -23,6 +29,7 @@ function Header (props: PropsWithChildren<{ className?: string }>): JSX.Element 
 function Row (props: PropsWithChildren<{ className?: string }>): JSX.Element {
   return (
     <div
+      data-testid='AdaptiveTable.Row'
       className={`overflow-hidden flex flex-wrap border rounded-lg lg:border-0 lg:rounded-none lg:table-row lg:border-t border-gray-200 ${props.className ?? ''}`}
     >
       {props.children}
@@ -32,7 +39,10 @@ function Row (props: PropsWithChildren<{ className?: string }>): JSX.Element {
 
 function Head (props: PropsWithChildren<{ className?: string }>): JSX.Element {
   return (
-    <div className={`table-cell py-3 px-6 text-black text-opacity-60 text-sm font-semibold ${props.className ?? ''}`}>
+    <div
+      data-testid='AdaptiveTable.Head'
+      className={`table-cell py-3 px-6 text-black text-opacity-60 text-sm font-semibold ${props.className ?? ''}`}
+    >
       {props.children}
     </div>
   )
@@ -40,7 +50,10 @@ function Head (props: PropsWithChildren<{ className?: string }>): JSX.Element {
 
 function Cell (props: PropsWithChildren<{ className?: string, title?: string }>): JSX.Element {
   return (
-    <div className={`table-cell w-full sm:w-auto flex-grow ${props.className ?? ''}`}>
+    <div
+      data-testid='AdaptiveTable.Cell'
+      className={`table-cell w-full sm:w-auto flex-grow ${props.className ?? ''}`}
+    >
       <div className='lg:hidden py-2 px-6 bg-gray-50 text-black text-opacity-60 text-xs font-semibold'>
         {props.title}
       </div>

--- a/src/components/commons/CursorPagination.tsx
+++ b/src/components/commons/CursorPagination.tsx
@@ -38,15 +38,15 @@ export function CursorPagination (props: CursorPaginationProps): JSX.Element {
   return (
     <div className={props.className}>
       <div className='flex space-x-2'>
-        <NavigateButton path={props.path} {...prev} type='prev'>
+        <NavigateButton.Prev path={props.path} cursors={prev.cursors}>
           <MdNavigateBefore className='h-6 w-6' />
-        </NavigateButton>
+        </NavigateButton.Prev>
         {pages.map(page => (
           <NumberButton key={page.n} path={props.path} {...page} />
         ))}
-        <NavigateButton path={props.path} {...next} type='next'>
+        <NavigateButton.Next path={props.path} cursors={next.cursors}>
           <MdNavigateNext className='h-6 w-6' />
-        </NavigateButton>
+        </NavigateButton.Next>
       </div>
     </div>
   )
@@ -74,7 +74,15 @@ function NumberButton (props: CursorPage & { path: string }): JSX.Element {
   )
 }
 
-function NavigateButton (props: PropsWithChildren<{ path: string, cursors: string[] | undefined, type: string }>): JSX.Element {
+NavigateButton.Prev = (props: PropsWithChildren<{ path: string, cursors: string[] | undefined }>) => {
+  return NavigateButton({ type: 'Prev', ...props })
+}
+
+NavigateButton.Next = (props: PropsWithChildren<{ path: string, cursors: string[] | undefined }>) => {
+  return NavigateButton({ type: 'Next', ...props })
+}
+
+function NavigateButton (props: PropsWithChildren<{ path: string, cursors: string[] | undefined, type: 'Next' | 'Prev' }>): JSX.Element {
   if (props.cursors === undefined) {
     return (
       <div className='bg-gray-50 rounded border border-gray-200 text-gray-600 opacity-40 cursor-not-allowed'>
@@ -88,7 +96,7 @@ function NavigateButton (props: PropsWithChildren<{ path: string, cursors: strin
   return (
     <Link href={{ pathname: props.path, query: getQueryFromCursors(props.cursors) }}>
       <a
-        data-testid={`navigate_button_${props.type}`}
+        data-testid={`NavigateButton${props.type}`}
         className='bg-gray-50 rounded border border-gray-200 text-gray-600 hover:border-primary hover:text-primary cursor-pointer'
       >
         <div className='h-11 w-11 flex items-center justify-center'>

--- a/src/components/commons/CursorPagination.tsx
+++ b/src/components/commons/CursorPagination.tsx
@@ -96,7 +96,7 @@ function NavigateButton (props: PropsWithChildren<{ path: string, cursors: strin
   return (
     <Link href={{ pathname: props.path, query: getQueryFromCursors(props.cursors) }}>
       <a
-        data-testid={`NavigateButton${props.type}`}
+        data-testid={`CursorPagination.${props.type}`}
         className='bg-gray-50 rounded border border-gray-200 text-gray-600 hover:border-primary hover:text-primary cursor-pointer'
       >
         <div className='h-11 w-11 flex items-center justify-center'>

--- a/src/components/commons/CursorPagination.tsx
+++ b/src/components/commons/CursorPagination.tsx
@@ -38,13 +38,13 @@ export function CursorPagination (props: CursorPaginationProps): JSX.Element {
   return (
     <div className={props.className}>
       <div className='flex space-x-2'>
-        <NavigateButton.Prev path={props.path} cursors={prev.cursors}>
+        <NavigateButton.Prev path={props.path} cursors={prev?.cursors}>
           <MdNavigateBefore className='h-6 w-6' />
         </NavigateButton.Prev>
         {pages.map(page => (
           <NumberButton key={page.n} path={props.path} {...page} />
         ))}
-        <NavigateButton.Next path={props.path} cursors={next.cursors}>
+        <NavigateButton.Next path={props.path} cursors={next?.cursors}>
           <MdNavigateNext className='h-6 w-6' />
         </NavigateButton.Next>
       </div>

--- a/src/pages/tokens/index.tsx
+++ b/src/pages/tokens/index.tsx
@@ -1,13 +1,11 @@
-import { GetServerSidePropsContext, GetServerSidePropsResult, InferGetServerSidePropsType } from 'next'
-
-import { getWhaleApiClient } from '@contexts/WhaleContext'
-import { TokenData } from '@defichain/whale-api-client/dist/api/tokens'
-import { tokens } from '@defichain/whale-api-client'
-
 import { AdaptiveTable } from '@components/commons/AdaptiveTable'
-import { getTokenIcon } from '@components/icons/tokens'
-import { Head } from '@components/commons/Head'
 import { CursorPage, CursorPagination } from '@components/commons/CursorPagination'
+import { Head } from '@components/commons/Head'
+import { getAssetIcon } from '@components/icons/assets'
+import { getWhaleApiClient } from '@contexts/WhaleContext'
+import { tokens } from '@defichain/whale-api-client'
+import { TokenData } from '@defichain/whale-api-client/dist/api/tokens'
+import { GetServerSidePropsContext, GetServerSidePropsResult, InferGetServerSidePropsType } from 'next'
 
 interface TokensPageData {
   tokens: {
@@ -28,6 +26,7 @@ export default function TokensPage ({ tokens }: InferGetServerSidePropsType<type
           <AdaptiveTable.Head className='text-right'>CATEGORY</AdaptiveTable.Head>
           <AdaptiveTable.Head className='text-right flex items-center'>MINTED</AdaptiveTable.Head>
         </AdaptiveTable.Header>
+
         {tokens.items.map((data: TokenData) => (
           <TokenRow data={data} key={data.id} />
         ))}
@@ -40,7 +39,8 @@ export default function TokensPage ({ tokens }: InferGetServerSidePropsType<type
 }
 
 function TokenRow ({ data }: { data: TokenData }): JSX.Element {
-  const TokenIcon = getTokenIcon(data.symbol)
+  const TokenIcon = getAssetIcon(data.symbol)
+
   return (
     <AdaptiveTable.Row>
       <AdaptiveTable.Cell title='TOKEN NAME' className='align-middle'>

--- a/src/pages/tokens/index.tsx
+++ b/src/pages/tokens/index.tsx
@@ -19,7 +19,7 @@ export default function TokensPage ({ tokens }: InferGetServerSidePropsType<type
   return (
     <div className='container mx-auto px-4 pt-12 pb-20'>
       <Head title='Tokens' />
-      <h1 data-testid='page_title' className='text-2xl font-semibold'>Tokens</h1>
+      <h1 className='text-2xl font-semibold'>Tokens</h1>
       <AdaptiveTable className='mt-6'>
         <AdaptiveTable.Header>
           <AdaptiveTable.Head>TOKEN</AdaptiveTable.Head>
@@ -53,7 +53,7 @@ function TokenRow ({ data }: { data: TokenData }): JSX.Element {
             const TokenIcon = getTokenIcon(data.symbol)
             return <TokenIcon className='h-8 w-8' />
           })()}
-          <span className='font-medium ml-3'>{data.symbol}</span>
+          <div className='font-medium ml-3'>{data.symbol}</div>
         </div>
       </AdaptiveTable.Cell>
       <AdaptiveTable.Cell title='NAME' className='align-middle'>
@@ -65,7 +65,7 @@ function TokenRow ({ data }: { data: TokenData }): JSX.Element {
           return data.name
         })()}
       </AdaptiveTable.Cell>
-      <AdaptiveTable.Cell title='CATEGORIES' className='align-middle'>
+      <AdaptiveTable.Cell title='CATEGORY' className='align-middle'>
         {(() => {
           if (data.isLPS) {
             return 'LPS'

--- a/src/pages/tokens/index.tsx
+++ b/src/pages/tokens/index.tsx
@@ -1,11 +1,12 @@
 import { AdaptiveTable } from '@components/commons/AdaptiveTable'
 import { CursorPage, CursorPagination } from '@components/commons/CursorPagination'
 import { Head } from '@components/commons/Head'
-import { getAssetIcon } from '@components/icons/assets'
+import { getAssetIcon, getTokenIcon } from '@components/icons/assets'
 import { getWhaleApiClient } from '@contexts/WhaleContext'
 import { tokens } from '@defichain/whale-api-client'
 import { TokenData } from '@defichain/whale-api-client/dist/api/tokens'
 import { GetServerSidePropsContext, GetServerSidePropsResult, InferGetServerSidePropsType } from 'next'
+import NumberFormat from 'react-number-format'
 
 interface TokensPageData {
   tokens: {
@@ -21,10 +22,10 @@ export default function TokensPage ({ tokens }: InferGetServerSidePropsType<type
       <h1 data-testid='page_title' className='text-2xl font-semibold'>Tokens</h1>
       <AdaptiveTable className='mt-6'>
         <AdaptiveTable.Header>
-          <AdaptiveTable.Head className='flex items-center'>TOKEN NAME</AdaptiveTable.Head>
-          <AdaptiveTable.Head className='text-right'>SYMBOL</AdaptiveTable.Head>
-          <AdaptiveTable.Head className='text-right'>CATEGORY</AdaptiveTable.Head>
-          <AdaptiveTable.Head className='text-right flex items-center'>MINTED</AdaptiveTable.Head>
+          <AdaptiveTable.Head>TOKEN</AdaptiveTable.Head>
+          <AdaptiveTable.Head>NAME</AdaptiveTable.Head>
+          <AdaptiveTable.Head>CATEGORY</AdaptiveTable.Head>
+          <AdaptiveTable.Head>MINTED</AdaptiveTable.Head>
         </AdaptiveTable.Header>
 
         {tokens.items.map((data: TokenData) => (
@@ -39,24 +40,78 @@ export default function TokensPage ({ tokens }: InferGetServerSidePropsType<type
 }
 
 function TokenRow ({ data }: { data: TokenData }): JSX.Element {
-  const TokenIcon = getAssetIcon(data.symbol)
-
   return (
     <AdaptiveTable.Row>
-      <AdaptiveTable.Cell title='TOKEN NAME' className='align-middle'>
+      <AdaptiveTable.Cell title='SYMBOL' className='align-middle'>
         <div className='flex items-center'>
-          <TokenIcon className='h-8 w-8 mr-2' />
-          {data.name}
+          {(() => {
+            if (data.isLPS) {
+              const [a, b] = data.symbol.split('-')
+              const AssetIconA = getAssetIcon(a)
+              const AssetIconB = getAssetIcon(b)
+              return (
+                <div>
+                  <AssetIconA
+                    className='h-8 w-8 absolute'
+                    style={{ clipPath: 'inset(0 50% 0 0)' }}
+                  />
+                  <AssetIconB className='h-8 w-8' />
+                </div>
+              )
+            }
+
+            if (data.isDAT) {
+              const AssetIcon = getAssetIcon(data.symbol)
+              return <AssetIcon className='h-8 w-8' />
+            }
+
+            const TokenIcon = getTokenIcon(data.symbol)
+            return <TokenIcon className='h-8 w-8' />
+          })()}
+          <span className='font-medium ml-3'>{data.symbol}</span>
         </div>
       </AdaptiveTable.Cell>
-      <AdaptiveTable.Cell title='SYMBOL' className='align-middle lg:text-right'>
-        <div>{data.symbol}</div>
+      <AdaptiveTable.Cell title='NAME' className='align-middle'>
+        {(() => {
+          if (data.isDAT) {
+            return data.name.replace('Default Defi token', 'DeFi Token')
+          }
+
+          return data.name
+        })()}
       </AdaptiveTable.Cell>
-      <AdaptiveTable.Cell title='CATEGORIES' className='align-middle lg:text-right'>
-        <div>{data.isDAT ? 'DAT' : 'LPS'}</div>
+      <AdaptiveTable.Cell title='CATEGORIES' className='align-middle'>
+        {(() => {
+          if (data.isLPS) {
+            return 'LPS'
+          }
+
+          if (data.isDAT) {
+            return 'DAT'
+          }
+
+          return 'DCT'
+        })()}
       </AdaptiveTable.Cell>
-      <AdaptiveTable.Cell title='MINTED' className='align-middle lg:text-right'>
-        <div>{data.minted}</div>
+      <AdaptiveTable.Cell title='MINTED' className='align-middle'>
+        {(() => {
+          if (data.isLPS) {
+            return <div>...</div>
+          }
+
+          if (data.id === '0') {
+            return <div>...</div>
+          }
+
+          return (
+            <NumberFormat
+              value={data.minted}
+              displayType='text'
+              thousandSeparator
+              decimalScale={2}
+            />
+          )
+        })()}
       </AdaptiveTable.Cell>
     </AdaptiveTable.Row>
   )

--- a/src/pages/tokens/index.tsx
+++ b/src/pages/tokens/index.tsx
@@ -45,21 +45,6 @@ function TokenRow ({ data }: { data: TokenData }): JSX.Element {
       <AdaptiveTable.Cell title='SYMBOL' className='align-middle'>
         <div className='flex items-center'>
           {(() => {
-            if (data.isLPS) {
-              const [a, b] = data.symbol.split('-')
-              const AssetIconA = getAssetIcon(a)
-              const AssetIconB = getAssetIcon(b)
-              return (
-                <div>
-                  <AssetIconA
-                    className='h-8 w-8 absolute'
-                    style={{ clipPath: 'inset(0 50% 0 0)' }}
-                  />
-                  <AssetIconB className='h-8 w-8' />
-                </div>
-              )
-            }
-
             if (data.isDAT) {
               const AssetIcon = getAssetIcon(data.symbol)
               return <AssetIcon className='h-8 w-8' />

--- a/src/pages/tokens/index.tsx
+++ b/src/pages/tokens/index.tsx
@@ -45,7 +45,7 @@ function TokenRow ({ data }: { data: TokenData }): JSX.Element {
     <AdaptiveTable.Row>
       <AdaptiveTable.Cell title='TOKEN NAME' className='align-middle'>
         <div className='flex items-center'>
-          <TokenIcon className='mr-2' />
+          <TokenIcon className='h-8 w-8 mr-2' />
           {data.name}
         </div>
       </AdaptiveTable.Cell>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### Code Sanity Refactoring
- added a more sane testing approach without having to `> > >`.
- updated all `data-testid` to be the component name e.g. `AdaptiveTable.Head`
- for more obvious testid like page title since we should only have 1 `<h1>` per page, just use that instead.
- [ ] add mobile screen size testing and replicate your tests across from desktop and mobile. (create another PR after both this and your PR has been merged.)

#### Design Inconsistency (doesn't match, please be more diligent and conscious)
- added conditional rendering for icons (please take note of isDAT, isLPS)
- added a more sane number rendering approach
- design isn't using text-right, please follow and use text-left (omitted as left is default)
- CATEGORIES -> CATEGORY

#### Changes I made on my own accord that drifts from specs

- `SYMBOL | NAME` instead of `NAME | SYMBOL`
