### PR TITLE
minor sanity refactoring for cypress and `icons/assets`

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -4,6 +4,7 @@
   "baseUrl": "http://localhost:3000",
   "viewportWidth": 1200,
   "viewportHeight": 1000,
+  "defaultCommandTimeout": 8000,
   "retries": {
     "runMode": 2,
     "openMode": 0

--- a/src/components/icons/assets/_Default.tsx
+++ b/src/components/icons/assets/_Default.tsx
@@ -3,19 +3,18 @@ import { SVGProps } from 'react'
 
 export function _Default (symbol: string): (props: SVGProps<SVGSVGElement>) => JSX.Element {
   return (props: SVGProps<SVGSVGElement>): JSX.Element => {
-    const color = randomColor({ luminosity: 'dark', seed: symbol })
-    const startingLetter = symbol?.substring(0, 1) ?? 'T'
+    const bg = randomColor({ luminosity: 'bright', format: 'rgba', seed: symbol, alpha: 0.2 })
+    const text = randomColor({ luminosity: 'dark', format: 'rgba', seed: symbol, alpha: 100 })
+    const first = symbol?.substring(0, 1)
 
     return (
-      <svg width='1em' height='1em' {...props}>
-        <circle cx={16} cy={16} r={16} fill={color} />
-        <text
-          x='50%' y='50%' alignmentBaseline='central' textAnchor='middle' fontWeight='bolder'
-          fontSize='24' fill='#ffffff'
-        >
-          {startingLetter}
-        </text>
-      </svg>
+      <div className={props.className}>
+        <div className='rounded-full w-full h-full' style={{ backgroundColor: bg }}>
+          <div className='w-full h-full flex items-center'>
+            <div className='flex-1 w-1 text-center font-semibold' style={{ color: text }}>{first}</div>
+          </div>
+        </div>
+      </div>
     )
   }
 }

--- a/src/components/icons/assets/index.ts
+++ b/src/components/icons/assets/index.ts
@@ -24,24 +24,27 @@ const mapping: Record<string, (props: SVGProps<SVGSVGElement>) => JSX.Element> =
   dUSDC: dUSDC
 }
 
+// TODO(@defich): move assets into it's own repo where anyone can create pull request into.
+//  Following a vector specification guideline, this allows anyone to create PR into that repo.
+
 /**
- * ```ts
- * const Icon = getTokenIcon('DFI')
- * const dIcon = getTokenIcon('dDOGE')
- *
- * return (
- *  <dIcon />
- * )
- * ```
- *
- * TODO(@defich): move assets into it's own repo where anyone can create pull request into.
- *  Following a vector specification guideline, this allows anyone to create PR into that repo.
- *
  * @param {string} symbol of the asset icon
  * @return {(props: SVGProps<SVGSVGElement>) => JSX.Element}
  */
 export function getAssetIcon (symbol: string): (props: SVGProps<SVGSVGElement>) => JSX.Element {
-  return getNativeIcon(`d${symbol}`)
+  const Icon = mapping[`d${symbol}`]
+  if (Icon === undefined) {
+    return _Default(symbol)
+  }
+  return Icon
+}
+
+/**
+ * @param {string} symbol of the token icon, AKA DCT
+ * @return {(props: SVGProps<SVGSVGElement>) => JSX.Element}
+ */
+export function getTokenIcon (symbol: string): (props: { className: string }) => JSX.Element {
+  return _Default(symbol)
 }
 
 /**


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

- cypress.json 8000ms sanity timeout
- @components/icons/assets update to handle getAssetIcon, getNativeIcon, getTokenIcon
