### PR TITLE
refactor tokens details

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -2,7 +2,9 @@
   <code_scheme name="Project" version="173">
     <option name="FORMATTER_TAGS_ENABLED" value="true" />
     <HTMLCodeStyleSettings>
+      <option name="HTML_KEEP_WHITESPACES" value="true" />
       <option name="HTML_SPACE_INSIDE_EMPTY_TAG" value="true" />
+      <option name="HTML_QUOTE_STYLE" value="Single" />
     </HTMLCodeStyleSettings>
     <JSCodeStyleSettings version="0">
       <option name="USE_SEMICOLON_AFTER_STATEMENT" value="false" />
@@ -13,7 +15,6 @@
       <option name="OBJECT_LITERAL_WRAP" value="2" />
       <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
       <option name="SPACES_WITHIN_IMPORTS" value="true" />
-      <option name="IMPORT_SORT_MODULE_NAME" value="true" />
     </JSCodeStyleSettings>
     <TypeScriptCodeStyleSettings version="0">
       <option name="USE_SEMICOLON_AFTER_STATEMENT" value="false" />
@@ -24,8 +25,14 @@
       <option name="OBJECT_LITERAL_WRAP" value="2" />
       <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
       <option name="SPACES_WITHIN_IMPORTS" value="true" />
-      <option name="IMPORT_SORT_MODULE_NAME" value="true" />
     </TypeScriptCodeStyleSettings>
+    <codeStyleSettings language="HTML">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
     <codeStyleSettings language="JavaScript">
       <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
       <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -2,7 +2,6 @@
   <code_scheme name="Project" version="173">
     <option name="FORMATTER_TAGS_ENABLED" value="true" />
     <HTMLCodeStyleSettings>
-      <option name="HTML_KEEP_WHITESPACES" value="true" />
       <option name="HTML_SPACE_INSIDE_EMPTY_TAG" value="true" />
       <option name="HTML_QUOTE_STYLE" value="Single" />
     </HTMLCodeStyleSettings>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,7 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
-    <option name="myName" value="Project Default"/>
-    <inspection_tool class="HtmlRequiredTitleElement" enabled="false" level="WARNING" enabled_by_default="false"/>
-    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true"/>
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="HtmlRequiredTitleElement" enabled="false" level="WARNING" enabled_by_default="false" />
   </profile>
 </component>

--- a/cypress/integration/pages/tokens/tokens-[symbol].spec.ts
+++ b/cypress/integration/pages/tokens/tokens-[symbol].spec.ts
@@ -4,7 +4,7 @@ context('/tokens/1 (Ether) Desktop', () => {
   })
 
   it('should have page header', function () {
-  cy.findByTestId('PageHeading').should('contain.text', 'Ether')
+    cy.findByTestId('PageHeading').should('contain.text', 'Ether')
   })
 
   it('should have <BreadCrums />', function () {

--- a/src/components/commons/AdaptiveList.tsx
+++ b/src/components/commons/AdaptiveList.tsx
@@ -7,7 +7,9 @@ export function AdaptiveList (props: PropsWithChildren<{ className?: string }>):
       data-testid='AdaptiveList'
       className={classNames(
         'divide-y divide-gray-200 border-gray-200',
-        'lg:border lg:rounded-lg', props.className)}
+        'lg:border lg:rounded-lg',
+        props.className
+      )}
     >
       {props.children}
     </div>
@@ -20,7 +22,7 @@ function Row (props: PropsWithChildren<{ name: string, className?: string }>): J
       <div className='min-w-24 lg:min-w-56 flex-shrink-0'>
         {props.name}:
       </div>
-      <div className={classNames('', props.className)}>
+      <div className={classNames('text-gray-600', props.className)}>
         {props.children}
       </div>
     </div>

--- a/src/components/commons/AdaptiveList.tsx
+++ b/src/components/commons/AdaptiveList.tsx
@@ -5,7 +5,9 @@ export function AdaptiveList (props: PropsWithChildren<{ className?: string }>):
   return (
     <div
       data-testid='AdaptiveList'
-      className={classNames('divide-y divide-gray-200 h-full lg:border lg:rounded-lg overflow-hidden w-full border-gray-200', props.className)}
+      className={classNames(
+        'divide-y divide-gray-200 border-gray-200',
+        'lg:border lg:rounded-lg', props.className)}
     >
       {props.children}
     </div>
@@ -18,7 +20,7 @@ function Row (props: PropsWithChildren<{ name: string, className?: string }>): J
       <div className='min-w-24 lg:min-w-56 flex-shrink-0'>
         {props.name}:
       </div>
-      <div className={classNames('text-black opacity-60', props.className)}>
+      <div className={classNames('', props.className)}>
         {props.children}
       </div>
     </div>

--- a/src/components/commons/AdaptiveList.tsx
+++ b/src/components/commons/AdaptiveList.tsx
@@ -6,23 +6,25 @@ export function AdaptiveList (props: PropsWithChildren<{ className?: string }>):
     <div
       data-testid='AdaptiveList'
       className={classNames(
-        'divide-y divide-gray-200 border-gray-200',
-        'lg:border lg:rounded-lg',
-        props.className
+        'rounded-lg border overflow-hidden', props.className
       )}
     >
-      {props.children}
+      <div className='table w-full border-collapse'>
+        <div className='table-row-group'>
+          {props.children}
+        </div>
+      </div>
     </div>
   )
 }
 
 function Row (props: PropsWithChildren<{ name: string, className?: string }>): JSX.Element {
   return (
-    <div className='flex items-center py-3 pl-6 pr-4'>
-      <div className='min-w-24 lg:min-w-56 flex-shrink-0'>
+    <div className='table-row border-b last:border-b-0'>
+      <div className='table-cell px-6 py-3'>
         {props.name}:
       </div>
-      <div className={classNames('text-gray-600', props.className)}>
+      <div className={classNames('table-cell px-6 py-3 text-gray-600', props.className)}>
         {props.children}
       </div>
     </div>

--- a/src/components/dex/PoolPairs.tsx
+++ b/src/components/dex/PoolPairs.tsx
@@ -6,7 +6,7 @@ import { getAssetIcon } from '@components/icons/assets'
 import NumberFormat from 'react-number-format'
 import BigNumber from 'bignumber.js'
 
-export function PoolPairsTable ({ poolPairs }: {poolPairs: PoolPairData[]}): JSX.Element {
+export function PoolPairsTable ({ poolPairs }: { poolPairs: PoolPairData[] }): JSX.Element {
   return (
     <AdaptiveTable className='mt-6'>
       <AdaptiveTable.Header>
@@ -17,9 +17,13 @@ export function PoolPairsTable ({ poolPairs }: {poolPairs: PoolPairData[]}): JSX
         <AdaptiveTable.Head>
           <div className='flex items-center justify-end'>
             <div>APR</div>
-            <HoverPopover popover='On defiscan.live, only block rewards are included in the APR calculation. With commission, the expected APR is much higher. We will update this soon.'>
+            <HoverPopover
+              popover='On defiscan.live, only block rewards are included in the APR calculation. With commission, the expected APR is much higher. We will update this soon.'
+            >
               <div className='p-1 cursor-help'>
-                <IoAlertCircle className='h-4 w-4 text-black opacity-60 group-hover:text-primary group-hover:opacity-100' />
+                <IoAlertCircle
+                  className='h-4 w-4 text-black opacity-60 group-hover:text-primary group-hover:opacity-100'
+                />
               </div>
             </HoverPopover>
           </div>

--- a/src/pages/dex/index.tsx
+++ b/src/pages/dex/index.tsx
@@ -6,7 +6,7 @@ import { RootState } from '@store/index'
 import { GetServerSidePropsContext, GetServerSidePropsResult, InferGetServerSidePropsType } from 'next'
 import NumberFormat from 'react-number-format'
 import { useSelector } from 'react-redux'
-import { PoolPairsTable } from '@components/commons/tables/PoolPairs'
+import { PoolPairsTable } from '@components/dex/PoolPairs'
 
 interface DexPageProps {
   poolPairs: {

--- a/src/pages/tokens/[id].tsx
+++ b/src/pages/tokens/[id].tsx
@@ -15,7 +15,7 @@ export default function TokenIdPage (props: InferGetServerSidePropsType<typeof g
     <div className='container mx-auto px-4 pt-12 pb-24'>
       <TokenPageHeading token={props.token} />
 
-      <div className='flex flex-col md:flex-row md:space-x-8 mt-6'>
+      <div className='flex flex-col space-y-6 mt-6 items-start lg:flex-row lg:space-x-8 lg:space-y-0'>
         <ListLeft token={props.token} />
         <ListRight token={props.token} />
       </div>

--- a/src/pages/tokens/[id].tsx
+++ b/src/pages/tokens/[id].tsx
@@ -1,11 +1,10 @@
-import { GetServerSidePropsContext, GetServerSidePropsResult, InferGetServerSidePropsType } from 'next'
-import { getWhaleApiClient } from '@contexts/WhaleContext'
-import { TokenData } from '@defichain/whale-api-client/dist/api/tokens'
 import { AdaptiveList } from '@components/commons/AdaptiveList'
 import { Breadcrumb } from '@components/commons/Breadcrumb'
-
 import { getAssetIcon, getTokenIcon } from '@components/icons/assets'
-import { IoAlertCircleOutline, IoCheckmarkCircleOutline, IoCopyOutline } from 'react-icons/io5'
+import { getWhaleApiClient } from '@contexts/WhaleContext'
+import { TokenData } from '@defichain/whale-api-client/dist/api/tokens'
+import { GetServerSidePropsContext, GetServerSidePropsResult, InferGetServerSidePropsType } from 'next'
+import { IoAlertCircleOutline, IoCheckmarkCircle } from 'react-icons/io5'
 
 interface TokenAssetPageProps {
   token: TokenData
@@ -13,9 +12,10 @@ interface TokenAssetPageProps {
 
 export default function TokenIdPage (props: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element {
   return (
-    <div className='container mx-auto px-4 pt-12 pb-20'>
+    <div className='container mx-auto px-4 pt-12 pb-24'>
       <TokenPageHeading token={props.token} />
-      <div className='flex flex-col md:flex-row md:space-x-8'>
+
+      <div className='flex flex-col md:flex-row md:space-x-8 mt-6'>
         <ListLeft token={props.token} />
         <ListRight token={props.token} />
       </div>
@@ -23,38 +23,45 @@ export default function TokenIdPage (props: InferGetServerSidePropsType<typeof g
   )
 }
 
+function getName (token: TokenData): string {
+  if (token.isDAT) {
+    return token.name.replace('Default Defi token', 'DeFiChain')
+  }
+
+  return token.name
+}
+
 function TokenPageHeading ({ token }: { token: TokenData }): JSX.Element {
-  const TokenIcon = getTokenIcon(token.symbol)
+  const name = getName(token)
+
   return (
     <div>
       <Breadcrumb items={[
-        { path: '/tokens', name: 'Tokens' },
-        { path: `/tokens/${token.id}`, name: `${token.name}`, hide: false, canonical: true }
+        {
+          path: '/tokens',
+          name: 'Tokens'
+        },
+        {
+          path: `/tokens/${token.id}`,
+          name: `${name}`,
+          hide: false,
+          canonical: true
+        }
       ]}
       />
-      <div className='flex flex-row flex-wrap items-center my-4'>
-        {(() => {
-          const AssetIcon = getAssetIcon(token.symbol)
-          if (token.isDAT) {
-            return (
-              <>
-                <AssetIcon className='h-8 w-8 mr-4' />
-                <h1
-                  data-testid='PageHeading'
-                  className='text-2xl font-semibold'
-                >{token.name.replace('Default Defi token', 'DeFiChain')}
-                </h1>
-              </>
-            )
-          }
-          return (
-            <>
-              <TokenIcon className='h-8 w-8 mr-4' />
-              <h1 data-test-id='PageHeading' className='text-2xl font-semibold'>{token.name}</h1>
-            </>
-          )
-        })()}
-      </div>
+
+      {(() => {
+        const Icon = token.isDAT ? getAssetIcon(token.symbol) : getTokenIcon(token.symbol)
+
+        return (
+          <div className='flex flex-row flex-wrap items-center mt-4'>
+            <Icon className='h-10 w-10 mr-4' />
+            <h1 data-testid='PageHeading' className='text-2xl font-semibold'>
+              {name}
+            </h1>
+          </div>
+        )
+      })()}
     </div>
   )
 }
@@ -69,13 +76,17 @@ function ListRight ({ token }: { token: TokenData }): JSX.Element {
         {(() => {
           if (token.tradeable) {
             return (
-              <span className='flex flex-wrap items-center'>Yes <IoCheckmarkCircleOutline className='h-4 w-4 text-green-500 ml-1' />
-              </span>
+              <div className='flex flex-wrap items-center'>
+                <div>Yes</div>
+                <IoCheckmarkCircle className='h-4 w-4 text-green-500 ml-1' />
+              </div>
             )
           }
           return (
-            <span className='flex flex-wrap items-center'>No <IoAlertCircleOutline className='h-4 w-4 text-gray-500 ml-1' />
-            </span>
+            <div className='flex flex-wrap items-center'>
+              <div>No</div>
+              <IoAlertCircleOutline className='h-4 w-4 text-gray-500 ml-1' />
+            </div>
           )
         })()}
       </AdaptiveList.Row>
@@ -83,7 +94,6 @@ function ListRight ({ token }: { token: TokenData }): JSX.Element {
       <AdaptiveList.Row name='Destruction Height'>{token.destruction.height}</AdaptiveList.Row>
       <AdaptiveList.Row name='Destruction TX' className='flex space-x-10 items-center'>
         <div className='break-all'>{token.destruction.tx}</div>
-        <CopyButton value={token.destruction.tx} />
       </AdaptiveList.Row>
     </AdaptiveList>
   )
@@ -99,13 +109,17 @@ function ListLeft ({ token }: { token: TokenData }): JSX.Element {
         {(() => {
           if (token.mintable) {
             return (
-              <span className='flex flex-wrap items-center'>Yes <IoCheckmarkCircleOutline className='h-4 w-4 text-green-500 ml-1' />
-              </span>
+              <div className='flex flex-wrap items-center'>
+                <div>Yes</div>
+                <IoCheckmarkCircle className='h-4 w-4 text-green-500 ml-1' />
+              </div>
             )
           }
           return (
-            <span className='flex flex-wrap items-center'>No <IoAlertCircleOutline className='h-4 w-4 text-gray-500 ml-1' />
-            </span>
+            <div className='flex flex-wrap items-center'>
+              <div>No</div>
+              <IoAlertCircleOutline className='h-4 w-4 text-gray-500 ml-1' />
+            </div>
           )
         })()}
       </AdaptiveList.Row>
@@ -113,26 +127,13 @@ function ListLeft ({ token }: { token: TokenData }): JSX.Element {
       <AdaptiveList.Row name='Creation Height'>{token.creation.height}</AdaptiveList.Row>
       <AdaptiveList.Row name='Creation Tx' className='flex space-x-10 items-center'>
         <div className='break-all'>{token.creation.tx}</div>
-        <CopyButton value={token.creation.tx} />
       </AdaptiveList.Row>
-      {(token.collateralAddress !== 'undefined') && (
+      {(token.collateralAddress !== undefined && token.collateralAddress !== 'undefined') && (
         <AdaptiveList.Row name='Collateral Address' className='flex space-x-10 items-center'>
           <div className='break-all'>{token.collateralAddress}</div>
-          <CopyButton value={token.collateralAddress!} />
         </AdaptiveList.Row>
       )}
     </AdaptiveList>
-  )
-}
-
-function CopyButton ({ value }: { value: string }): JSX.Element {
-  return (
-    <button
-      onClick={async () => await navigator.clipboard.writeText(value)}
-      className='cursor-pointer outline-none p-2 bg-gray-100 border border-black border-opacity-60 rounded'
-    >
-      <IoCopyOutline className='h-5 w-5 text-black opacity-60' />
-    </button>
   )
 }
 

--- a/src/pages/tokens/index.tsx
+++ b/src/pages/tokens/index.tsx
@@ -1,13 +1,13 @@
 import { AdaptiveTable } from '@components/commons/AdaptiveTable'
 import { CursorPage, CursorPagination } from '@components/commons/CursorPagination'
 import { Head } from '@components/commons/Head'
+import { Link } from '@components/commons/Link'
 import { getAssetIcon, getTokenIcon } from '@components/icons/assets'
 import { getWhaleApiClient } from '@contexts/WhaleContext'
 import { tokens } from '@defichain/whale-api-client'
 import { TokenData } from '@defichain/whale-api-client/dist/api/tokens'
 import { GetServerSidePropsContext, GetServerSidePropsResult, InferGetServerSidePropsType } from 'next'
 import NumberFormat from 'react-number-format'
-import { Link } from '@components/commons/Link'
 
 interface TokensPageData {
   tokens: {
@@ -37,9 +37,15 @@ export default function TokensPage ({ tokens }: InferGetServerSidePropsType<type
           <AdaptiveTable.Head>MINTED</AdaptiveTable.Head>
         </AdaptiveTable.Header>
 
-        {tokens.items.map((data: TokenData) => (
-          <TokenRow data={data} key={data.id} />
-        ))}
+        {tokens.items.map((data: TokenData) => {
+          return (
+            <Link href={{ pathname: `/tokens/${data.id}` }} key={data.id}>
+              <a className='contents'>
+                <TokenRow data={data} />
+              </a>
+            </Link>
+          )
+        })}
       </AdaptiveTable>
       <div className='flex justify-end mt-8'>
         <CursorPagination pages={tokens.pages} path='/tokens' />
@@ -50,7 +56,7 @@ export default function TokensPage ({ tokens }: InferGetServerSidePropsType<type
 
 function TokenRow ({ data }: { data: TokenData }): JSX.Element {
   return (
-    <AdaptiveTable.Row>
+    <AdaptiveTable.Row className='group cursor-pointer'>
       <AdaptiveTable.Cell title='SYMBOL' className='align-middle'>
         <div className='flex items-center'>
           {(() => {
@@ -62,12 +68,12 @@ function TokenRow ({ data }: { data: TokenData }): JSX.Element {
             const TokenIcon = getTokenIcon(data.symbol)
             return <TokenIcon className='h-8 w-8' />
           })()}
-          <div className='font-medium ml-3 text-primary'>
-            <Link href={{ pathname: `/tokens/${data.id}` }}>{data.symbol}</Link>
+          <div className='font-medium ml-3 group-hover:text-primary'>
+            {data.symbol}
           </div>
         </div>
       </AdaptiveTable.Cell>
-      <AdaptiveTable.Cell title='NAME' className='align-middle'>
+      <AdaptiveTable.Cell title='NAME' className='align-middle group-hover:text-primary'>
         {(() => {
           if (data.isDAT) {
             return data.name.replace('Default Defi token', 'DeFiChain')
@@ -76,7 +82,7 @@ function TokenRow ({ data }: { data: TokenData }): JSX.Element {
           return data.name
         })()}
       </AdaptiveTable.Cell>
-      <AdaptiveTable.Cell title='CATEGORY' className='align-middle'>
+      <AdaptiveTable.Cell title='CATEGORY' className='align-middle group-hover:text-primary'>
         {(() => {
           if (data.isLPS) {
             return 'LPS'
@@ -89,7 +95,7 @@ function TokenRow ({ data }: { data: TokenData }): JSX.Element {
           return 'DCT'
         })()}
       </AdaptiveTable.Cell>
-      <AdaptiveTable.Cell title='MINTED' className='align-middle'>
+      <AdaptiveTable.Cell title='MINTED' className='align-middle group-hover:text-primary'>
         {(() => {
           if (data.isLPS) {
             return <div>...</div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,15 +12,13 @@ module.exports = {
     extend: {
       colors: {
         primary: '#ff00af',
-      },
-      minWidth: {
-        '24':'6rem',
-        '56': '14rem'
       }
     }
   },
   variants: {
-    extend: {}
+    extend: {
+      borderWidth: ['last'],
+    }
   },
   plugins: [
     require('@tailwindcss/line-clamp'),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor
/kind fix

#### What this PR does / why we need it:

- fixed tokens-[symbol].spec.ts indentation
- moved `PoolPairs.tsx` to components/dex because it's not a common component, it's a dex specific component
- refactor entire `<TokenRow>` to be a clickable row with hover-group indicator
- For AdaptiveList, don't use opacity-60 on the parent component as it affects child component colors, text-color is more adaptive and consistency for child adaptability 
- Removed content-copy as there isn't any real utility to copying transactions. Users can double click select to copy.
- Removed minWidth extension for tailwind, the developer should stray away from setting number specific utility as that makes it harder to maintain in the long run
- For AdaptiveList, opt to use a table instead of flex. As `table` provides automatic sizing while flex requires min-width sizing. We could use a grid but a table is the natural choice for this and is more widely supported. Also removed lg breakpoint that removes the border as it looks weird and isn't part of the design language now. Let's just wait for finalized rendered before attempting to implement any mobile-specific designs.
