### PR TITLE
cypress: `npm run start` instead of `npm run dev`

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -37,7 +37,7 @@ jobs:
           record: true
           parallel: true
           build: npm run build
-          start: npm run dev
+          start: npm run start
           wait-on: 'http://localhost:3000/prices'
           browser: chrome
           spec: cypress/integration/**


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

Swapped from `npm run dev` to `npm run start` to fix cypress flaky test performance for PriceFeed due to unpredictable build time. 

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #232

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [ ] Tested on multiple web browsers
- [ ] Tested responsiveness (e.g, iPhone, iPad, Desktop)
- [ ] No console errors
- [ ] Unit tests*
- [ ] Added e2e tests*

<!-- 
* If applicable 
-->
