### PR TITLE
set dependabot update schedule to daily from weekly to further shift left deps update timeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
-      day: 'thursday'
+      interval: 'daily'
     labels:
       - "kind/dependencies"
     ignore:


### PR DESCRIPTION
#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore