### PR TITLE
Update default dev env network to MainNet

### DIFF
--- a/src/layouts/contexts/Environment.ts
+++ b/src/layouts/contexts/Environment.ts
@@ -44,10 +44,10 @@ export function getEnvironment (): Environment {
     case 'development':
     default:
       return new Environment('Development', true, [
+        Network.MainNet,
         Network.RemotePlayground,
         Network.LocalPlayground,
-        Network.TestNet,
-        Network.MainNet
+        Network.TestNet
       ])
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:
Changes the default development network to MainNet to match default production env. This would allow devs to include the addition of links/href cypress test cases.

Currently in the dev environment, ?network=MainNet will be appended to `href` attributes of every `<Link>` component as MainNet is not default env. If test cases are written to check for urls including the "?network=MainNet" the test cases will pass local/dev env but fail in the CI/prod env and vice versa.
