### PR TITLE
dependabot not to ignore defichain deps update as they have been set to exact

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,7 @@ updates:
       interval: 'daily'
     labels:
       - "kind/dependencies"
-    ignore:
-      - dependency-name: "@defichain/*"
+    versioning-strategy: 'increase'
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

With upstream packages updated to use exact versioning. This PR tests DeFiCh/scan dependabot set up to automatically update without running a custom script. (The script isn't disabled yet.)