### PR TITLE
dependabot added back ignore, it only works for peers deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: 'daily'
     labels:
       - "kind/dependencies"
+    ignore:
+      - dependency-name: "@defichain/*"
     versioning-strategy: 'increase'
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

