### PR TITLE
Removed warning header for blocks and txns page

### DIFF
--- a/src/components/transactions/[txid]/TransactionHeadings.tsx
+++ b/src/components/transactions/[txid]/TransactionHeadings.tsx
@@ -1,5 +1,4 @@
 import { Transaction } from '@defichain/whale-api-client/dist/api/transactions'
-import { useNetwork } from '@contexts/NetworkContext'
 import { CopyButton } from '@components/commons/CopyButton'
 
 interface TransactionHeadingProps {
@@ -11,29 +10,8 @@ interface TransactionNotFoundHeadingProps {
 }
 
 export function TransactionHeading (props: TransactionHeadingProps): JSX.Element {
-  const network = useNetwork()
-
   return (
     <>
-      <div className='flex items-center justify-center pb-6'>
-        <div className='bg-orange-100 rounded p-3 text-center'>
-          🚧 Work in progress, this is an early iteration of defiscan.live/transactions/*. Some features are not
-          available and may not work as expected.
-          {network === 'MainNet' && (
-            <>
-              <br />In the meantime, you can use
-              <a
-                target='_blank'
-                href={`https://explorer.defichain.io/#/DFI/mainnet/tx/${props.transaction.id}`}
-                className='cursor-pointer hover:underline text-primary-500 break-all ml-1' rel='noreferrer'
-              >
-                https://explorer.defichain.com
-              </a>.
-            </>
-          )}
-        </div>
-      </div>
-
       <span className='leading-6 opacity-60' data-testid='title'>
         Transaction ID
       </span>

--- a/src/pages/blocks/[blockId]/index.tsx
+++ b/src/pages/blocks/[blockId]/index.tsx
@@ -36,13 +36,6 @@ export default function BlockDetails (props: InferGetServerSidePropsType<typeof 
 function BlockHeading ({ block }: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element {
   return (
     <>
-      <div className='flex items-center justify-center pb-6'>
-        <div className='bg-orange-100 rounded p-3'>
-          🚧 Work in progress, this is an early iteration of defiscan.live/blocks/*. Some features are not available and
-          may not work as expected.
-        </div>
-      </div>
-
       <Head title={`Block #${block.height}`} />
 
       <Breadcrumb items={[

--- a/src/pages/blocks/index.tsx
+++ b/src/pages/blocks/index.tsx
@@ -23,13 +23,6 @@ export default function Blocks ({ blocks }: InferGetServerSidePropsType<typeof g
     <Container className='pt-12 pb-20'>
       <Head title='Blocks' />
 
-      <div className='flex items-center justify-center pb-6'>
-        <div className='bg-orange-100 rounded p-3'>
-          🚧 Work in progress, this is an early iteration of defiscan.live/blocks. Some features are not available and
-          may not work as expected.
-        </div>
-      </div>
-
       <h1 className='text-2xl font-medium'>Blocks</h1>
 
       <div className='my-6'>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

Removes the warning banner for blocks and transaction pages
