### PR TITLE
add direct connection to RPC within cypress testing for scan

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -24,12 +24,20 @@ jobs:
         containers: [ 1, 2, 3, 4, 5 ]
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+
+      - name: Setup Playground
+        run: docker-compose -f docker-compose.yml up -d
+
       - uses: actions/setup-node@270253e841af726300e85d718a5f606959b2903c
         with:
           node-version: 16
           cache: 'npm'
 
       - run: npm ci
+
+      - run: .github/workflows/ci/wait-for http://localhost:3001/_actuator/probes/liveness -t 120
+      - run: .github/workflows/ci/wait-for http://localhost:3002/_actuator/probes/liveness -t 120
+      - run: .github/workflows/ci/wait-for http://localhost:19551/ping -t 120
 
       - uses: cypress-io/github-action@2113e5bc19c45979ba123df6e07256d2aaba9a33
         with:

--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -219,6 +219,7 @@
       <w>vout</w>
       <w>vouts</w>
       <w>vsize</w>
+      <w>waitfornewblock</w>
       <w>walletname</w>
       <w>walletversion</w>
       <w>wpkh</w>

--- a/cypress/integration/pages/vaults/index.spec.ts
+++ b/cypress/integration/pages/vaults/index.spec.ts
@@ -1,5 +1,5 @@
 import { PlaygroundApiClient, PlaygroundRpcClient } from '@defichain/playground-api-client'
-import { wait } from 'next/dist/build/output/log'
+import { RegTestFoundationKeys } from '@defichain/jellyfish-network'
 
 const api = new PlaygroundApiClient({
   url: 'http://localhost:19553'
@@ -19,8 +19,14 @@ context('/vaults', () => {
         loanSchemeId: '1',
         ownerAddress: address
       })
-      // this method isn't mapped yet, so we are calling it raw via `rpc.call`
-      await rpc.call('waitfornewblock', [], 'number')
+      await rpc.blockchain.waitForNewBlock()
+
+      await rpc.loan.depositToVault({
+        vaultId: vaultId,
+        from: RegTestFoundationKeys[0].operator.address,
+        amount: '1@BTC'
+      })
+      await rpc.blockchain.waitForNewBlock()
       return vaultId
     })
 

--- a/cypress/integration/pages/vaults/index.spec.ts
+++ b/cypress/integration/pages/vaults/index.spec.ts
@@ -1,0 +1,30 @@
+import { PlaygroundApiClient, PlaygroundRpcClient } from '@defichain/playground-api-client'
+import { wait } from 'next/dist/build/output/log'
+
+const api = new PlaygroundApiClient({
+  url: 'http://localhost:19553'
+})
+const rpc = new PlaygroundRpcClient(api)
+
+context('/vaults', () => {
+  beforeEach(() => {
+    cy.viewport('macbook-13')
+  })
+
+  it('should have vaultId', async () => {
+    let vaultId
+    cy.wrap(null).then(async () => {
+      const address = await rpc.wallet.getNewAddress()
+      vaultId = await rpc.loan.createVault({
+        loanSchemeId: '1',
+        ownerAddress: address
+      })
+      // this method isn't mapped yet, so we are calling it raw via `rpc.call`
+      await rpc.call('waitfornewblock', [], 'number')
+      return vaultId
+    })
+
+    cy.visit('/vaults?network=Local')
+    // cy.findByTestId('TEST_JSON').contains('ownerAddress')
+  })
+})

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -3,6 +3,7 @@
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "strict": true,
+    "moduleResolution": "node",
     "target": "esnext",
     "lib": [
       "esnext",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   defi-blockchain:
-    image: defi/defichain:1.8.4
+    image: defi/defichain:2.0.0
     command: >
       defid
       -printtoconsole
@@ -41,9 +41,10 @@ services:
       -dakotacrescentheight=5
       -eunosheight=6
       -eunospayaheight=7
+      -fortcanningheight=8
 
   defi-playground:
-    image: ghcr.io/defich/playground:0.10.0
+    image: ghcr.io/defich/playground:0.11.1
     depends_on:
       - defi-blockchain
     ports:
@@ -56,7 +57,7 @@ services:
       - "traefik.http.routers.playground.entrypoints=web"
 
   defi-whale:
-    image: ghcr.io/defich/whale:0.11.4
+    image: ghcr.io/defich/whale:0.13.0
     depends_on:
       - defi-blockchain
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   defi-blockchain:
-    image: defi/defichain:2.0.0
+    image: defi/defichain:HEAD-65cf498
     command: >
       defid
       -printtoconsole
@@ -44,7 +44,7 @@ services:
       -fortcanningheight=8
 
   defi-playground:
-    image: ghcr.io/defich/playground:0.11.1
+    image: ghcr.io/defich/playground:0.11.2
     depends_on:
       - defi-blockchain
     ports:
@@ -57,7 +57,7 @@ services:
       - "traefik.http.routers.playground.entrypoints=web"
 
   defi-whale:
-    image: ghcr.io/defich/whale:0.13.0
+    image: ghcr.io/defich/whale:0.13.2
     depends_on:
       - defi-blockchain
     ports:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-address": "0.48.1",
-        "@defichain/jellyfish-transaction": "0.48.1",
-        "@defichain/playground-api-client": "0.10.0",
-        "@defichain/whale-api-client": "0.11.5",
+        "@defichain/jellyfish-address": "^2.0.0",
+        "@defichain/jellyfish-transaction": "^2.0.0",
+        "@defichain/playground-api-client": "^0.11.2",
+        "@defichain/whale-api-client": "^0.13.2",
         "@headlessui/react": "^1.4.2",
         "@popperjs/core": "^2.10.2",
         "@reduxjs/toolkit": "^1.6.2",
@@ -20,6 +20,7 @@
         "bignumber.js": "^9.0.1",
         "classnames": "^2.3.1",
         "date-fns": "^2.25.0",
+        "defichain": "^2.0.0",
         "lodash": "^4.17.21",
         "next": "12.0.3",
         "next-sitemap": "^1.6.189",
@@ -1901,47 +1902,47 @@
       "dev": true
     },
     "node_modules/@defichain/jellyfish-address": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-0.48.1.tgz",
-      "integrity": "sha512-qjC+wIc0CBEurEqZFaxeCR6P1BTRNBOm5h0It/PcMsqAgeKJ47ionjDrBgiHD1OqXL8Fgbt8cOR4oS1p1m6kOw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-2.0.0.tgz",
+      "integrity": "sha512-HPd18T9rqC0AIktuFEfNa/d/7y/2zK7j7CgTPYbxBCLS3k1167XGIQO8P7K4qjXXQrYIprPYY306x68nKdu6Cw==",
       "dependencies": {
-        "@defichain/jellyfish-crypto": "0.48.1",
-        "@defichain/jellyfish-network": "0.48.1",
-        "@defichain/jellyfish-transaction": "0.48.1",
+        "@defichain/jellyfish-crypto": "2.0.0",
+        "@defichain/jellyfish-network": "2.0.0",
+        "@defichain/jellyfish-transaction": "2.0.0",
         "bech32": "^2.0.0",
         "bs58": "^4.0.1"
       },
       "peerDependencies": {
-        "defichain": "0.48.1"
+        "defichain": "^2.0.0"
       }
     },
     "node_modules/@defichain/jellyfish-api-core": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-0.48.1.tgz",
-      "integrity": "sha512-yKLOyVmN23ELb8bFIve2N2nbzX62Ppj8rs46gASgxg04ongZyV80+Tq0en3jE7TH+4Qo19BlW7TaNyzpXt4kDQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-2.0.0.tgz",
+      "integrity": "sha512-Pdvn607RKP6ficDk+OPU8FuyyLszPOjL1evlUfUgUU7b8c5PvQzrjCkzQu4e7JfiO5f5a9PL/RO7H+kKmpoZ1w==",
       "dependencies": {
-        "@defichain/jellyfish-json": "0.48.1"
+        "@defichain/jellyfish-json": "2.0.0"
       },
       "peerDependencies": {
-        "defichain": "0.48.1"
+        "defichain": "^2.0.0"
       }
     },
     "node_modules/@defichain/jellyfish-buffer": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-buffer/-/jellyfish-buffer-0.48.1.tgz",
-      "integrity": "sha512-CrGLJQCIiv6CNPLg2eoOybKSd07BfJPVIi/couNUaeHcQmSlLNYmlIRcd+0qo4BOzz8BXk8J2SCYcq+X8/QqfA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-buffer/-/jellyfish-buffer-2.0.0.tgz",
+      "integrity": "sha512-9KG3C0J3LmWhoud8BU6QGlTzJm/TWvVQCSJXDPCSJREt1e6kwp6D497H7qVxPWLMHgrgcHsJxbmhzkIXmfEzQg==",
       "dependencies": {
         "bignumber.js": "^9.0.1",
         "smart-buffer": "^4.2.0"
       },
       "peerDependencies": {
-        "defichain": "0.48.1"
+        "defichain": "^2.0.0"
       }
     },
     "node_modules/@defichain/jellyfish-crypto": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.48.1.tgz",
-      "integrity": "sha512-dLDyjuODOszlqGtVhvcgCC3c823pFrv4RPe4sTwQtBAOVTu9pGrA/x67aT2uBgMk8g0pYaaEvjcPMzduQYLG2w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-2.0.0.tgz",
+      "integrity": "sha512-tRHgxniITpqndFN6dU1eWqVKFLYZBg3NCrSVhW0f7xm5kp2pUxf/d2lEOfRSJsR5cW13SZaKGzJWV/Bijj3c0Q==",
       "dependencies": {
         "bech32": "^2.0.0",
         "bip66": "^1.1.5",
@@ -1953,64 +1954,63 @@
         "wif": "^2.0.6"
       },
       "peerDependencies": {
-        "defichain": "0.48.1"
+        "defichain": "^2.0.0"
       }
     },
     "node_modules/@defichain/jellyfish-json": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-0.48.1.tgz",
-      "integrity": "sha512-7jpny6Wzb69J4TuMmOvSAWUuZmAjFP+iCIv8xOWz+zZN57SMAELZvwoZFSR82I1zULNRIFOp91SBadBtj9mQxA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-2.0.0.tgz",
+      "integrity": "sha512-xYqswGa2qCSE3vih5PyIFHC/50KamNSrXBTTXkNA7UfhtHfjt8yqT1WUP6/c1c0G/r39bEk/l6DmgBS5d9wY3g==",
       "dependencies": {
         "@types/lossless-json": "^1.0.1",
         "bignumber.js": "^9.0.1",
         "lossless-json": "^1.0.5"
       },
       "peerDependencies": {
-        "defichain": "0.48.1"
+        "defichain": "^2.0.0"
       }
     },
     "node_modules/@defichain/jellyfish-network": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-0.48.1.tgz",
-      "integrity": "sha512-aFl4fa+OsuBZpScgi0+rGQfbvOtvdjVLt87UQsYnPOunntdsyOsNurQJtOmSEsuNSb9djMNaxjvD/QkqO/QyLw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-2.0.0.tgz",
+      "integrity": "sha512-2EBuDITtuiLZmPUHYsn3g5Ezq/HQwX4pUUo26cTuwKn3oCjXh5pzNTcDviC20Emm3vAhrm4bBma99mSNdYJShg==",
       "peerDependencies": {
-        "defichain": "0.48.1"
+        "defichain": "^2.0.0"
       }
     },
     "node_modules/@defichain/jellyfish-transaction": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.48.1.tgz",
-      "integrity": "sha512-419+dCbPPQ2da8EzpRxXDPSK5IjyTLT0VG1BAy4xRR1DS0XX2uYqxSI63f5TQOdj27/xpymYd92zWuSVmr5tiA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-2.0.0.tgz",
+      "integrity": "sha512-QkoA+cnkkKZitAo8b/CnjlLO4zyDmYuNr5ak72jQ8+niMBz25Nvjix1izBQpKa2oOr/+/Asri4CUJGHZ96K7Fg==",
       "dependencies": {
-        "@defichain/jellyfish-buffer": "0.48.1",
-        "@defichain/jellyfish-crypto": "0.48.1"
+        "@defichain/jellyfish-buffer": "2.0.0",
+        "@defichain/jellyfish-crypto": "2.0.0"
       },
       "peerDependencies": {
-        "defichain": "0.48.1"
+        "defichain": "^2.0.0"
       }
     },
     "node_modules/@defichain/playground-api-client": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@defichain/playground-api-client/-/playground-api-client-0.10.0.tgz",
-      "integrity": "sha512-5TqRPHdCCoCM8A5fnbFeckIqO9XnN0bojaqlg76YSDy4k1XCYZfAlvcNzT9hderXdZll4pkv8EMMxjG/kIQzbw==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@defichain/playground-api-client/-/playground-api-client-0.11.2.tgz",
+      "integrity": "sha512-19qeizysIr3cUGLarFp/aX8cYqJx0lADNlZ8szVi/yFTpfWShU4trdX3Kdma1+41Bj24tb+exkFNWHDJBI9pQw==",
       "dependencies": {
-        "@defichain/jellyfish-api-core": ">=0.45.1",
+        "@defichain/jellyfish-api-core": "^2.0.0",
         "abort-controller": "^3.0.0",
-        "cross-fetch": "^3.1.2"
+        "cross-fetch": "^3.1.4",
+        "defichain": "^2.0.0"
       }
     },
     "node_modules/@defichain/whale-api-client": {
-      "version": "0.11.5",
-      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.11.5.tgz",
-      "integrity": "sha512-7whh9shqp7c56Hm9CC0h2wXDCnXxTtlZHLS6biVPaDM96NZLcfw8aRQHEpYepIw0jBWVL8zwYHqTCuc5cO7r2w==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.13.2.tgz",
+      "integrity": "sha512-t9ACrrHvue0/wYNlFFgVwXbQDnjMHscANQEbipkwUfcWAtVPPrLBDb8jtNIBp3N6rgUIx1fD2Be80Dji+oViAw==",
       "dependencies": {
-        "@defichain/jellyfish-api-core": "^0.48.1",
+        "@defichain/jellyfish-api-core": "^2.0.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.2",
+        "defichain": "^2.0.0",
         "url-search-params-polyfill": "8.1.1"
-      },
-      "peerDependencies": {
-        "defichain": "^0.48.1"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -4451,9 +4451,9 @@
       }
     },
     "node_modules/base-x": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
-      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -6074,10 +6074,9 @@
       }
     },
     "node_modules/defichain": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/defichain/-/defichain-0.48.1.tgz",
-      "integrity": "sha512-v/U0HPKUBceAfvxUz93Jvd6+vexV3G5MUTcClV2jErp0dao57h0R4wmjYGINoypxQwTnA9nghkzArUhvm862FQ==",
-      "peer": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.0.0.tgz",
+      "integrity": "sha512-oEnFLJAWw0G4U1zxV7LJp3rIqU9RHtO28DsoXCckTEADknoZbQaaHnW96N+fbgN7WufAmvCRoxw1ckX3JMuhPA==",
       "engines": {
         "node": ">=14.x"
       }
@@ -16461,38 +16460,38 @@
       }
     },
     "@defichain/jellyfish-address": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-0.48.1.tgz",
-      "integrity": "sha512-qjC+wIc0CBEurEqZFaxeCR6P1BTRNBOm5h0It/PcMsqAgeKJ47ionjDrBgiHD1OqXL8Fgbt8cOR4oS1p1m6kOw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-2.0.0.tgz",
+      "integrity": "sha512-HPd18T9rqC0AIktuFEfNa/d/7y/2zK7j7CgTPYbxBCLS3k1167XGIQO8P7K4qjXXQrYIprPYY306x68nKdu6Cw==",
       "requires": {
-        "@defichain/jellyfish-crypto": "0.48.1",
-        "@defichain/jellyfish-network": "0.48.1",
-        "@defichain/jellyfish-transaction": "0.48.1",
+        "@defichain/jellyfish-crypto": "2.0.0",
+        "@defichain/jellyfish-network": "2.0.0",
+        "@defichain/jellyfish-transaction": "2.0.0",
         "bech32": "^2.0.0",
         "bs58": "^4.0.1"
       }
     },
     "@defichain/jellyfish-api-core": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-0.48.1.tgz",
-      "integrity": "sha512-yKLOyVmN23ELb8bFIve2N2nbzX62Ppj8rs46gASgxg04ongZyV80+Tq0en3jE7TH+4Qo19BlW7TaNyzpXt4kDQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-2.0.0.tgz",
+      "integrity": "sha512-Pdvn607RKP6ficDk+OPU8FuyyLszPOjL1evlUfUgUU7b8c5PvQzrjCkzQu4e7JfiO5f5a9PL/RO7H+kKmpoZ1w==",
       "requires": {
-        "@defichain/jellyfish-json": "0.48.1"
+        "@defichain/jellyfish-json": "2.0.0"
       }
     },
     "@defichain/jellyfish-buffer": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-buffer/-/jellyfish-buffer-0.48.1.tgz",
-      "integrity": "sha512-CrGLJQCIiv6CNPLg2eoOybKSd07BfJPVIi/couNUaeHcQmSlLNYmlIRcd+0qo4BOzz8BXk8J2SCYcq+X8/QqfA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-buffer/-/jellyfish-buffer-2.0.0.tgz",
+      "integrity": "sha512-9KG3C0J3LmWhoud8BU6QGlTzJm/TWvVQCSJXDPCSJREt1e6kwp6D497H7qVxPWLMHgrgcHsJxbmhzkIXmfEzQg==",
       "requires": {
         "bignumber.js": "^9.0.1",
         "smart-buffer": "^4.2.0"
       }
     },
     "@defichain/jellyfish-crypto": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-0.48.1.tgz",
-      "integrity": "sha512-dLDyjuODOszlqGtVhvcgCC3c823pFrv4RPe4sTwQtBAOVTu9pGrA/x67aT2uBgMk8g0pYaaEvjcPMzduQYLG2w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-2.0.0.tgz",
+      "integrity": "sha512-tRHgxniITpqndFN6dU1eWqVKFLYZBg3NCrSVhW0f7xm5kp2pUxf/d2lEOfRSJsR5cW13SZaKGzJWV/Bijj3c0Q==",
       "requires": {
         "bech32": "^2.0.0",
         "bip66": "^1.1.5",
@@ -16505,9 +16504,9 @@
       }
     },
     "@defichain/jellyfish-json": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-0.48.1.tgz",
-      "integrity": "sha512-7jpny6Wzb69J4TuMmOvSAWUuZmAjFP+iCIv8xOWz+zZN57SMAELZvwoZFSR82I1zULNRIFOp91SBadBtj9mQxA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-2.0.0.tgz",
+      "integrity": "sha512-xYqswGa2qCSE3vih5PyIFHC/50KamNSrXBTTXkNA7UfhtHfjt8yqT1WUP6/c1c0G/r39bEk/l6DmgBS5d9wY3g==",
       "requires": {
         "@types/lossless-json": "^1.0.1",
         "bignumber.js": "^9.0.1",
@@ -16515,38 +16514,40 @@
       }
     },
     "@defichain/jellyfish-network": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-0.48.1.tgz",
-      "integrity": "sha512-aFl4fa+OsuBZpScgi0+rGQfbvOtvdjVLt87UQsYnPOunntdsyOsNurQJtOmSEsuNSb9djMNaxjvD/QkqO/QyLw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-2.0.0.tgz",
+      "integrity": "sha512-2EBuDITtuiLZmPUHYsn3g5Ezq/HQwX4pUUo26cTuwKn3oCjXh5pzNTcDviC20Emm3vAhrm4bBma99mSNdYJShg==",
       "requires": {}
     },
     "@defichain/jellyfish-transaction": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-0.48.1.tgz",
-      "integrity": "sha512-419+dCbPPQ2da8EzpRxXDPSK5IjyTLT0VG1BAy4xRR1DS0XX2uYqxSI63f5TQOdj27/xpymYd92zWuSVmr5tiA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-2.0.0.tgz",
+      "integrity": "sha512-QkoA+cnkkKZitAo8b/CnjlLO4zyDmYuNr5ak72jQ8+niMBz25Nvjix1izBQpKa2oOr/+/Asri4CUJGHZ96K7Fg==",
       "requires": {
-        "@defichain/jellyfish-buffer": "0.48.1",
-        "@defichain/jellyfish-crypto": "0.48.1"
+        "@defichain/jellyfish-buffer": "2.0.0",
+        "@defichain/jellyfish-crypto": "2.0.0"
       }
     },
     "@defichain/playground-api-client": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@defichain/playground-api-client/-/playground-api-client-0.10.0.tgz",
-      "integrity": "sha512-5TqRPHdCCoCM8A5fnbFeckIqO9XnN0bojaqlg76YSDy4k1XCYZfAlvcNzT9hderXdZll4pkv8EMMxjG/kIQzbw==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@defichain/playground-api-client/-/playground-api-client-0.11.2.tgz",
+      "integrity": "sha512-19qeizysIr3cUGLarFp/aX8cYqJx0lADNlZ8szVi/yFTpfWShU4trdX3Kdma1+41Bj24tb+exkFNWHDJBI9pQw==",
       "requires": {
-        "@defichain/jellyfish-api-core": ">=0.45.1",
+        "@defichain/jellyfish-api-core": "^2.0.0",
         "abort-controller": "^3.0.0",
-        "cross-fetch": "^3.1.2"
+        "cross-fetch": "^3.1.4",
+        "defichain": "^2.0.0"
       }
     },
     "@defichain/whale-api-client": {
-      "version": "0.11.5",
-      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.11.5.tgz",
-      "integrity": "sha512-7whh9shqp7c56Hm9CC0h2wXDCnXxTtlZHLS6biVPaDM96NZLcfw8aRQHEpYepIw0jBWVL8zwYHqTCuc5cO7r2w==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.13.2.tgz",
+      "integrity": "sha512-t9ACrrHvue0/wYNlFFgVwXbQDnjMHscANQEbipkwUfcWAtVPPrLBDb8jtNIBp3N6rgUIx1fD2Be80Dji+oViAw==",
       "requires": {
-        "@defichain/jellyfish-api-core": "^0.48.1",
+        "@defichain/jellyfish-api-core": "^2.0.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.2",
+        "defichain": "^2.0.0",
         "url-search-params-polyfill": "8.1.1"
       }
     },
@@ -18370,9 +18371,9 @@
       }
     },
     "base-x": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
-      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -19694,10 +19695,9 @@
       }
     },
     "defichain": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/defichain/-/defichain-0.48.1.tgz",
-      "integrity": "sha512-v/U0HPKUBceAfvxUz93Jvd6+vexV3G5MUTcClV2jErp0dao57h0R4wmjYGINoypxQwTnA9nghkzArUhvm862FQ==",
-      "peer": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.0.0.tgz",
+      "integrity": "sha512-oEnFLJAWw0G4U1zxV7LJp3rIqU9RHtO28DsoXCckTEADknoZbQaaHnW96N+fbgN7WufAmvCRoxw1ckX3JMuhPA=="
     },
     "define-properties": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "playground:start": "docker-compose rm -fsv && docker-compose up"
   },
   "dependencies": {
-    "@defichain/jellyfish-address": "^0.51.0",
-    "@defichain/jellyfish-transaction": "^0.51.0",
-    "@defichain/playground-api-client": "^0.11.1",
-    "@defichain/whale-api-client": "^0.13.0",
+    "@defichain/jellyfish-address": "^2.0.0",
+    "@defichain/jellyfish-transaction": "^2.0.0",
+    "@defichain/playground-api-client": "^0.11.2",
+    "@defichain/whale-api-client": "^0.13.2",
     "@headlessui/react": "^1.4.2",
     "@popperjs/core": "^2.10.2",
     "@reduxjs/toolkit": "^1.6.2",
@@ -27,6 +27,7 @@
     "bignumber.js": "^9.0.1",
     "classnames": "^2.3.1",
     "date-fns": "^2.25.0",
+    "defichain": "^2.0.0",
     "lodash": "^4.17.21",
     "next": "12.0.3",
     "next-sitemap": "^1.6.189",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "playground:start": "docker-compose rm -fsv && docker-compose up"
   },
   "dependencies": {
-    "@defichain/jellyfish-address": "0.48.1",
-    "@defichain/jellyfish-transaction": "0.48.1",
-    "@defichain/playground-api-client": "0.10.0",
-    "@defichain/whale-api-client": "0.11.5",
+    "@defichain/jellyfish-address": "^0.51.0",
+    "@defichain/jellyfish-transaction": "^0.51.0",
+    "@defichain/playground-api-client": "^0.11.1",
+    "@defichain/whale-api-client": "^0.13.0",
     "@headlessui/react": "^1.4.2",
     "@popperjs/core": "^2.10.2",
     "@reduxjs/toolkit": "^1.6.2",

--- a/src/layouts/contexts/Environment.ts
+++ b/src/layouts/contexts/Environment.ts
@@ -34,7 +34,8 @@ class Environment {
  * @return Environment of current setup, checked against Environment Variable
  */
 export function getEnvironment (): Environment {
-  switch (process.env.NODE_ENV) {
+  const type = process.env.CYPRESS === 'true' ? 'development' : process.env.NODE_ENV
+  switch (type) {
     case 'production':
       return new Environment('Production', false, [
         NetworkConnection.MainNet,

--- a/src/pages/vaults/index.tsx
+++ b/src/pages/vaults/index.tsx
@@ -1,0 +1,29 @@
+import { GetServerSidePropsContext, GetServerSidePropsResult, InferGetServerSidePropsType } from 'next'
+import { getWhaleApiClient } from '@contexts/WhaleContext'
+import { LoanVaultActive, LoanVaultLiquidated } from '@defichain/whale-api-client/dist/api/loan'
+import { Container } from '@components/commons/Container'
+
+interface VaultPageProps {
+  vaults: Array<LoanVaultActive | LoanVaultLiquidated>
+}
+
+export default function VaultPage (props: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element {
+  return (
+    <Container className='pt-12 pb-20'>
+      <div data-testid='TEST_JSON'>
+        <pre>{JSON.stringify(props.vaults, null, 2)}</pre>
+      </div>
+    </Container>
+  )
+}
+
+export async function getServerSideProps (context: GetServerSidePropsContext): Promise<GetServerSidePropsResult<VaultPageProps>> {
+  const api = getWhaleApiClient(context)
+  const vaults = await api.loan.listVault()
+
+  return {
+    props: {
+      vaults: [...vaults]
+    }
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

You can now use the playground RPC layer to directly mock your scenarios for testing.
- Updated `ci-e2e.yml` to setup container
- visit `http://localhost:3000/vaults?network=Local` to access local environment directly
    - npm run playground:start
    - npm run dev
    - npm run cypress:open

---
- [ ] We should add the Cypress flag during development, or we should change Cypress to Development? 
