### PR TITLE
Bump whale to 0.14.1 to support ActivePrice data within LoanToken, CollateralToken, VaultLoanTokenAmount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       -fortcanningheight=8
 
   defi-playground:
-    image: ghcr.io/defich/playground:0.11.2
+    image: ghcr.io/defich/playground:0.11.3
     depends_on:
       - defi-blockchain
     ports:
@@ -57,7 +57,7 @@ services:
       - "traefik.http.routers.playground.entrypoints=web"
 
   defi-whale:
-    image: ghcr.io/defich/whale:0.13.5
+    image: ghcr.io/defich/whale:0.14.1
     depends_on:
       - defi-blockchain
     ports:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-address": "2.1.1",
-        "@defichain/jellyfish-transaction": "2.1.1",
-        "@defichain/playground-api-client": "0.11.2",
-        "@defichain/whale-api-client": "0.13.5",
+        "@defichain/jellyfish-address": "^2.4.0",
+        "@defichain/jellyfish-transaction": "^2.4.0",
+        "@defichain/playground-api-client": "^0.11.3",
+        "@defichain/whale-api-client": "^0.14.1",
         "@headlessui/react": "^1.4.2",
         "@popperjs/core": "^2.10.2",
         "@reduxjs/toolkit": "^1.6.2",
@@ -20,6 +20,7 @@
         "bignumber.js": "^9.0.1",
         "classnames": "^2.3.1",
         "date-fns": "^2.25.0",
+        "defichain": "^2.4.0",
         "lodash": "^4.17.21",
         "next": "12.0.3",
         "next-sitemap": "^1.6.189",
@@ -1556,47 +1557,47 @@
       }
     },
     "node_modules/@defichain/jellyfish-address": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-2.1.1.tgz",
-      "integrity": "sha512-0PaoRfzQtr9TycX11ecrajCEjTXktywAvw3yYtjXjC01Bs4gmkhdEV8rfYYYvYRR/V+v3OblUYdv58GaYfhKoQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-2.4.0.tgz",
+      "integrity": "sha512-vBxeJ7GcHZzpqGh/aexdBe0eqE3tO0kl6akGPfPZZ1EGo3z0+99FPQxAOt5lTDO4hgIw4KK9IdfARiSFLNrcUQ==",
       "dependencies": {
-        "@defichain/jellyfish-crypto": "2.1.1",
-        "@defichain/jellyfish-network": "2.1.1",
-        "@defichain/jellyfish-transaction": "2.1.1",
+        "@defichain/jellyfish-crypto": "2.4.0",
+        "@defichain/jellyfish-network": "2.4.0",
+        "@defichain/jellyfish-transaction": "2.4.0",
         "bech32": "^2.0.0",
         "bs58": "^4.0.1"
       },
       "peerDependencies": {
-        "defichain": "^2.1.1"
+        "defichain": "^2.4.0"
       }
     },
     "node_modules/@defichain/jellyfish-api-core": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-2.1.1.tgz",
-      "integrity": "sha512-7weVRelZLNshbt7SCW7FKwV91Xbt+WGTEtfpEp+t4f1erQrMuIX3cfCBGYRSiA3Nt0cni0DPiN97I1BZ2Pml3Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-2.4.0.tgz",
+      "integrity": "sha512-JRCKwLl9qmNGXJiSqTru0B5s7567+iyG2TwL7AAim5TZM5wqeD5ACGyH5kV6/NMhUBpF+mpuaUj5q6TsURb5qQ==",
       "dependencies": {
-        "@defichain/jellyfish-json": "2.1.1"
+        "@defichain/jellyfish-json": "2.4.0"
       },
       "peerDependencies": {
-        "defichain": "^2.1.1"
+        "defichain": "^2.4.0"
       }
     },
     "node_modules/@defichain/jellyfish-buffer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-buffer/-/jellyfish-buffer-2.1.1.tgz",
-      "integrity": "sha512-i0mmn8/ZtskZvDvVee3j/FmKxqlLfiPvVjYJ3ZOwFtASfYeWGjPeBYm66ToPSetIPbIFpz4XxMmw4qm0rZ+ySw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-buffer/-/jellyfish-buffer-2.4.0.tgz",
+      "integrity": "sha512-Zw5TEl65Pz1LFRh/hyK6qdsbhR2QEQThulroyWGeByAI6hKKklBt3/Zf2dTakc/57SmefRLNQhlkF6KcgerS+Q==",
       "dependencies": {
         "bignumber.js": "^9.0.1",
         "smart-buffer": "^4.2.0"
       },
       "peerDependencies": {
-        "defichain": "^2.1.1"
+        "defichain": "^2.4.0"
       }
     },
     "node_modules/@defichain/jellyfish-crypto": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-2.1.1.tgz",
-      "integrity": "sha512-+bQRqg1nEQlLO/8euBsYVHMfGWrfEliLBURvV/Rf2+Uw5ZXkbg+jRRA6yNfdoz06zJMRWXzbGaaeYGDXMHheRg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-2.4.0.tgz",
+      "integrity": "sha512-5sjJPQuouFxTLF7sf2TLIefGefOm1zTLaJt4j1/PdklDTyb2Sh5+j+f0/a9S2MhPM2KSsH2behKe9jZgzK3f5w==",
       "dependencies": {
         "bech32": "^2.0.0",
         "bip66": "^1.1.5",
@@ -1608,46 +1609,46 @@
         "wif": "^2.0.6"
       },
       "peerDependencies": {
-        "defichain": "^2.1.1"
+        "defichain": "^2.4.0"
       }
     },
     "node_modules/@defichain/jellyfish-json": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-2.1.1.tgz",
-      "integrity": "sha512-hfweTKU08hvGO8IBhM0OeweDb8hACUitgpK4MB/eJs1PKTBYy/FfIAtYBIOw0czH6VWeFkTzC2n98Gw3U4Mrmw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-2.4.0.tgz",
+      "integrity": "sha512-TXKzksM4jAomHWyzppuE6kQG2YG0FudgNIqB87sSaP0az6QYtM35y6FSn+8AmH6Qc9A3+7hEtPl/wCv5KksT/w==",
       "dependencies": {
         "@types/lossless-json": "^1.0.1",
         "bignumber.js": "^9.0.1",
         "lossless-json": "^1.0.5"
       },
       "peerDependencies": {
-        "defichain": "^2.1.1"
+        "defichain": "^2.4.0"
       }
     },
     "node_modules/@defichain/jellyfish-network": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-2.1.1.tgz",
-      "integrity": "sha512-K36r38VW6U+STXeuVI2xG2HiGhGsB9vx77rXMOVV1C/a35X4oS2lDaxzao6dPvcciJs1pjDwHZJnesUBr1lgGg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-2.4.0.tgz",
+      "integrity": "sha512-Xp36ZqTvW++sb3DRNkCMQX2UrBLEoBVEq2FHk19sZfzTSmSCBxfyY1gf/3gLB3oiEVhHvDYmwvOXDVamAQfSJw==",
       "peerDependencies": {
-        "defichain": "^2.1.1"
+        "defichain": "^2.4.0"
       }
     },
     "node_modules/@defichain/jellyfish-transaction": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-2.1.1.tgz",
-      "integrity": "sha512-Fnh5Y6dOux9rycASQ7TWRf/cMNWhL2ZxSYoCgTrC59nodn92S4x/aGUc9P1Gzbvhjgm5Y5j2JxPqxSDsj+T8WA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-2.4.0.tgz",
+      "integrity": "sha512-9MkrTxKhAWXUxXpl5uWGHCd1QttLNAGypSoyjKua65R/ZQdRFi43W8VZ9rSlLez6hhscEC3HYqAZZDl/cARjjw==",
       "dependencies": {
-        "@defichain/jellyfish-buffer": "2.1.1",
-        "@defichain/jellyfish-crypto": "2.1.1"
+        "@defichain/jellyfish-buffer": "2.4.0",
+        "@defichain/jellyfish-crypto": "2.4.0"
       },
       "peerDependencies": {
-        "defichain": "^2.1.1"
+        "defichain": "^2.4.0"
       }
     },
     "node_modules/@defichain/playground-api-client": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@defichain/playground-api-client/-/playground-api-client-0.11.2.tgz",
-      "integrity": "sha512-19qeizysIr3cUGLarFp/aX8cYqJx0lADNlZ8szVi/yFTpfWShU4trdX3Kdma1+41Bj24tb+exkFNWHDJBI9pQw==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@defichain/playground-api-client/-/playground-api-client-0.11.3.tgz",
+      "integrity": "sha512-yaovAOrFyUl/4m4v1QJii2yL3sf+K1VYYPnAgcsK5AdfA+AJlFLLc1c1o4m7g2Oi6Nq4pmY3N6OfYBC6mCgAOQ==",
       "dependencies": {
         "@defichain/jellyfish-api-core": "^2.0.0",
         "abort-controller": "^3.0.0",
@@ -1656,15 +1657,17 @@
       }
     },
     "node_modules/@defichain/whale-api-client": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.13.5.tgz",
-      "integrity": "sha512-jOONgzSTmE2wrpGNL5q4MSjscDcghMZ3zSBj28JoG5iiNYrh7fBLk/Zzn3G5/ogV6QTnvwcJrbz7ix91vJHnIA==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.14.1.tgz",
+      "integrity": "sha512-EZe5WVv+tf0THxe3xQxnv5dDbusJPLe1ueGcSfbCJhmukhVNSZq4hii2RDGoL4MaHsRnBKShsshNPISSlF7kWw==",
       "dependencies": {
-        "@defichain/jellyfish-api-core": "^2.1.1",
+        "@defichain/jellyfish-api-core": "^2.4.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.2",
-        "defichain": "^2.1.1",
         "url-search-params-polyfill": "8.1.1"
+      },
+      "peerDependencies": {
+        "defichain": "^2.4.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -4931,9 +4934,9 @@
       }
     },
     "node_modules/defichain": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.1.1.tgz",
-      "integrity": "sha512-/C7nC+oo9gOL50YfZG0fPHSdM4ydIx4rd9vFwet/tlXGSHGdBXo5HLFzYzUtk3cHaWxOmIJVJnp03O3pvA/d+w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.4.0.tgz",
+      "integrity": "sha512-OUAvYsHdiXvbWJuZX1rYUZZ8231LzsZiPpQk33VDrysAVB4vr0004fW34098M40h2ijiJJi/0onnZBLjhxvCUQ==",
       "engines": {
         "node": ">=14.x"
       }
@@ -14882,38 +14885,38 @@
       }
     },
     "@defichain/jellyfish-address": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-2.1.1.tgz",
-      "integrity": "sha512-0PaoRfzQtr9TycX11ecrajCEjTXktywAvw3yYtjXjC01Bs4gmkhdEV8rfYYYvYRR/V+v3OblUYdv58GaYfhKoQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-address/-/jellyfish-address-2.4.0.tgz",
+      "integrity": "sha512-vBxeJ7GcHZzpqGh/aexdBe0eqE3tO0kl6akGPfPZZ1EGo3z0+99FPQxAOt5lTDO4hgIw4KK9IdfARiSFLNrcUQ==",
       "requires": {
-        "@defichain/jellyfish-crypto": "2.1.1",
-        "@defichain/jellyfish-network": "2.1.1",
-        "@defichain/jellyfish-transaction": "2.1.1",
+        "@defichain/jellyfish-crypto": "2.4.0",
+        "@defichain/jellyfish-network": "2.4.0",
+        "@defichain/jellyfish-transaction": "2.4.0",
         "bech32": "^2.0.0",
         "bs58": "^4.0.1"
       }
     },
     "@defichain/jellyfish-api-core": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-2.1.1.tgz",
-      "integrity": "sha512-7weVRelZLNshbt7SCW7FKwV91Xbt+WGTEtfpEp+t4f1erQrMuIX3cfCBGYRSiA3Nt0cni0DPiN97I1BZ2Pml3Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-2.4.0.tgz",
+      "integrity": "sha512-JRCKwLl9qmNGXJiSqTru0B5s7567+iyG2TwL7AAim5TZM5wqeD5ACGyH5kV6/NMhUBpF+mpuaUj5q6TsURb5qQ==",
       "requires": {
-        "@defichain/jellyfish-json": "2.1.1"
+        "@defichain/jellyfish-json": "2.4.0"
       }
     },
     "@defichain/jellyfish-buffer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-buffer/-/jellyfish-buffer-2.1.1.tgz",
-      "integrity": "sha512-i0mmn8/ZtskZvDvVee3j/FmKxqlLfiPvVjYJ3ZOwFtASfYeWGjPeBYm66ToPSetIPbIFpz4XxMmw4qm0rZ+ySw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-buffer/-/jellyfish-buffer-2.4.0.tgz",
+      "integrity": "sha512-Zw5TEl65Pz1LFRh/hyK6qdsbhR2QEQThulroyWGeByAI6hKKklBt3/Zf2dTakc/57SmefRLNQhlkF6KcgerS+Q==",
       "requires": {
         "bignumber.js": "^9.0.1",
         "smart-buffer": "^4.2.0"
       }
     },
     "@defichain/jellyfish-crypto": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-2.1.1.tgz",
-      "integrity": "sha512-+bQRqg1nEQlLO/8euBsYVHMfGWrfEliLBURvV/Rf2+Uw5ZXkbg+jRRA6yNfdoz06zJMRWXzbGaaeYGDXMHheRg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-crypto/-/jellyfish-crypto-2.4.0.tgz",
+      "integrity": "sha512-5sjJPQuouFxTLF7sf2TLIefGefOm1zTLaJt4j1/PdklDTyb2Sh5+j+f0/a9S2MhPM2KSsH2behKe9jZgzK3f5w==",
       "requires": {
         "bech32": "^2.0.0",
         "bip66": "^1.1.5",
@@ -14926,9 +14929,9 @@
       }
     },
     "@defichain/jellyfish-json": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-2.1.1.tgz",
-      "integrity": "sha512-hfweTKU08hvGO8IBhM0OeweDb8hACUitgpK4MB/eJs1PKTBYy/FfIAtYBIOw0czH6VWeFkTzC2n98Gw3U4Mrmw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-2.4.0.tgz",
+      "integrity": "sha512-TXKzksM4jAomHWyzppuE6kQG2YG0FudgNIqB87sSaP0az6QYtM35y6FSn+8AmH6Qc9A3+7hEtPl/wCv5KksT/w==",
       "requires": {
         "@types/lossless-json": "^1.0.1",
         "bignumber.js": "^9.0.1",
@@ -14936,24 +14939,24 @@
       }
     },
     "@defichain/jellyfish-network": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-2.1.1.tgz",
-      "integrity": "sha512-K36r38VW6U+STXeuVI2xG2HiGhGsB9vx77rXMOVV1C/a35X4oS2lDaxzao6dPvcciJs1pjDwHZJnesUBr1lgGg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-network/-/jellyfish-network-2.4.0.tgz",
+      "integrity": "sha512-Xp36ZqTvW++sb3DRNkCMQX2UrBLEoBVEq2FHk19sZfzTSmSCBxfyY1gf/3gLB3oiEVhHvDYmwvOXDVamAQfSJw==",
       "requires": {}
     },
     "@defichain/jellyfish-transaction": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-2.1.1.tgz",
-      "integrity": "sha512-Fnh5Y6dOux9rycASQ7TWRf/cMNWhL2ZxSYoCgTrC59nodn92S4x/aGUc9P1Gzbvhjgm5Y5j2JxPqxSDsj+T8WA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-transaction/-/jellyfish-transaction-2.4.0.tgz",
+      "integrity": "sha512-9MkrTxKhAWXUxXpl5uWGHCd1QttLNAGypSoyjKua65R/ZQdRFi43W8VZ9rSlLez6hhscEC3HYqAZZDl/cARjjw==",
       "requires": {
-        "@defichain/jellyfish-buffer": "2.1.1",
-        "@defichain/jellyfish-crypto": "2.1.1"
+        "@defichain/jellyfish-buffer": "2.4.0",
+        "@defichain/jellyfish-crypto": "2.4.0"
       }
     },
     "@defichain/playground-api-client": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@defichain/playground-api-client/-/playground-api-client-0.11.2.tgz",
-      "integrity": "sha512-19qeizysIr3cUGLarFp/aX8cYqJx0lADNlZ8szVi/yFTpfWShU4trdX3Kdma1+41Bj24tb+exkFNWHDJBI9pQw==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@defichain/playground-api-client/-/playground-api-client-0.11.3.tgz",
+      "integrity": "sha512-yaovAOrFyUl/4m4v1QJii2yL3sf+K1VYYPnAgcsK5AdfA+AJlFLLc1c1o4m7g2Oi6Nq4pmY3N6OfYBC6mCgAOQ==",
       "requires": {
         "@defichain/jellyfish-api-core": "^2.0.0",
         "abort-controller": "^3.0.0",
@@ -14962,14 +14965,13 @@
       }
     },
     "@defichain/whale-api-client": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.13.5.tgz",
-      "integrity": "sha512-jOONgzSTmE2wrpGNL5q4MSjscDcghMZ3zSBj28JoG5iiNYrh7fBLk/Zzn3G5/ogV6QTnvwcJrbz7ix91vJHnIA==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.14.1.tgz",
+      "integrity": "sha512-EZe5WVv+tf0THxe3xQxnv5dDbusJPLe1ueGcSfbCJhmukhVNSZq4hii2RDGoL4MaHsRnBKShsshNPISSlF7kWw==",
       "requires": {
-        "@defichain/jellyfish-api-core": "^2.1.1",
+        "@defichain/jellyfish-api-core": "^2.4.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.2",
-        "defichain": "^2.1.1",
         "url-search-params-polyfill": "8.1.1"
       }
     },
@@ -17483,9 +17485,9 @@
       }
     },
     "defichain": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.1.1.tgz",
-      "integrity": "sha512-/C7nC+oo9gOL50YfZG0fPHSdM4ydIx4rd9vFwet/tlXGSHGdBXo5HLFzYzUtk3cHaWxOmIJVJnp03O3pvA/d+w=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.4.0.tgz",
+      "integrity": "sha512-OUAvYsHdiXvbWJuZX1rYUZZ8231LzsZiPpQk33VDrysAVB4vr0004fW34098M40h2ijiJJi/0onnZBLjhxvCUQ=="
     },
     "define-properties": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "playground:start": "docker-compose rm -fsv && docker-compose up"
   },
   "dependencies": {
-    "@defichain/jellyfish-address": "2.1.1",
-    "@defichain/jellyfish-transaction": "2.1.1",
-    "@defichain/playground-api-client": "0.11.2",
-    "@defichain/whale-api-client": "0.13.5",
+    "@defichain/jellyfish-address": "^2.4.0",
+    "@defichain/jellyfish-transaction": "^2.4.0",
+    "@defichain/playground-api-client": "^0.11.3",
+    "@defichain/whale-api-client": "^0.14.1",
     "@headlessui/react": "^1.4.2",
     "@popperjs/core": "^2.10.2",
     "@reduxjs/toolkit": "^1.6.2",
@@ -27,6 +27,7 @@
     "bignumber.js": "^9.0.1",
     "classnames": "^2.3.1",
     "date-fns": "^2.25.0",
+    "defichain": "^2.4.0",
     "lodash": "^4.17.21",
     "next": "12.0.3",
     "next-sitemap": "^1.6.189",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind dependencies

Add `ActivePrice` to `LoanToken`, `CollateralToken` and `VaultLoanTokenAmount` for convenience. This data can be undefined at the root or deeply within for different conditions (next/current halt), need to handle those conditions.

- This PR contains 1 very minor breaking change, rename of `LoanCollateralToken.priceFeedId` to `LoanCollateralToken.fixedIntervalPriceId`.
- MainNet deployment is not yet ready, this is only applicable in Playground till then.