### PR TITLE
hide BURN-DFI temporary from /dex

### DIFF
--- a/src/components/dex/PoolPairs.tsx
+++ b/src/components/dex/PoolPairs.tsx
@@ -40,6 +40,10 @@ export function PoolPairsTable ({ poolPairs }: { poolPairs: PoolPairData[] }): J
 }
 
 function PoolPairRow ({ data }: { data: PoolPairData }): JSX.Element {
+  if (data.symbol === 'BURN-DFI') {
+    return <></>
+  }
+
   return (
     <AdaptiveTable.Row>
       <AdaptiveTable.Cell title='PAIR' className='align-middle'>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

Hide `BURN-DFI` temporarily from being shown on `/dex`.
