### PR TITLE
Added ws://localhost:3000/ into connect-src

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,7 +12,7 @@ const securityHeaders = [
       `script-src 'self' app.netlify.com netlify-cdp-loader.netlify.app ${process.env.NODE_ENV === 'development' ? `'unsafe-eval'` : ''};` +
       `style-src 'self' fonts.googleapis.com 'unsafe-inline';` +
       `font-src fonts.gstatic.com;` +
-      `connect-src 'self' ocean.defichain.com;` +
+      `connect-src 'self' ocean.defichain.com ${process.env.NODE_ENV === 'development' ? `ws://localhost:3000/_next/webpack-hmr` : ''};` +
       `prefetch-src 'self';`
   },
   {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:
Adds `ws://localhost:3000/_next/webpack-hmr` into connect-src when in development env. As local dev servers were not loading on Safari as it enforces connect-src policy.