### PR TITLE
Fix RemainingTokensIcon alignment on Safari

### DIFF
--- a/src/pages/vaults/_components/commons/RemainingTokensIcon.tsx
+++ b/src/pages/vaults/_components/commons/RemainingTokensIcon.tsx
@@ -12,21 +12,19 @@ export function RemainingTokensIcon ({ tokensCount }: RemainingTokensIconProps):
         fontSize={fontSize}
         fontWeight='700'
         fill='#2b2b2b'
-        dominantBaseline='middle'
-        textAnchor='middle'
         dy='.05em'
       >
         {(() => {
           if (tokensCount > 99) {
             return (
-              <tspan x='50%' y='50%' fontSize='22' dy='.1em'>
+              <tspan x='50%' y='50%' fontSize='22' dy='.1em' dominantBaseline='middle' textAnchor='middle'>
                 ∞
               </tspan>
             )
           }
 
           return (
-            <tspan x='50%' y='50%'>
+            <tspan x='50%' y='50%' dominantBaseline='middle' textAnchor='middle'>
               +{tokensCount}
             </tspan>
           )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

Fixes RemainingTokensIcon text alignment on Safari.

![image](https://user-images.githubusercontent.com/4586209/149688085-20fc3146-5485-47ff-aade-8b35af2bb095.png)

