### PR TITLE
chore(dependencies): migrate playground-api to use DeFiCh/jellyfish/apps release

### DIFF
--- a/.github/workflows/defichain-dependencies.yml
+++ b/.github/workflows/defichain-dependencies.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Upgrade dependencies
         run: |
-          npx npm-check-updates -l m -u --deep --target newest --pre -f "/defichain|^@defichain\/.+/" -x "/^@defichain\/(whale|playground)-.+/" \
+          npx npm-check-updates -l m -u --deep --target newest --pre -f "/defichain|^@defichain\/.+/" -x "/^@defichain\/(whale)-.+/" \
           | grep -q 'Run npm install to install new versions' && \
           npm i
 
@@ -65,33 +65,3 @@ jobs:
             #### What this PR does / why we need it:
             Bump `@defichain/whale` dependencies to the latest release.
           branch: defichain-bot/bump-whale-deps
-
-  playground:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
-      - uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a
-        with:
-          node-version: 16
-
-      - name: Upgrade dependencies
-        run: |
-          npx npm-check-updates -l m -u --deep --target newest --pre -f "/^@defichain\/playground-.+/" \
-          | grep -q 'Run npm install to install new versions' && \
-          npm i
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672
-        with:
-          token: ${{ secrets.DEFICHAIN_BOT_GITHUB_TOKEN }}
-          labels: kind/dependencies
-          committer: DeFiChain Bot <github-bot@defichain.com>
-          author: DeFiChain Bot <github-bot@defichain.com>
-          title: Bump @defichain/playground dependencies
-          commit-message: Bump @defichain/playground dependencies
-          body: |
-            #### What kind of PR is this?:
-            /kind dependencies
-            #### What this PR does / why we need it:
-            Bump `@defichain/playground` dependencies to the latest release.
-          branch: defichain-bot/bump-playground-deps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       -fortcanninghillheight=10
 
   defi-playground:
-    image: ghcr.io/defich/playground:0.15.0
+    image: ghcr.io/defich/playground-api:2.28.2
     depends_on:
       - defi-blockchain
     ports:
@@ -59,7 +59,7 @@ services:
       - "traefik.http.routers.playground.entrypoints=web"
 
   defi-whale:
-    image: ghcr.io/defich/whale:0.19.1
+    image: ghcr.io/defich/whale:0.27.0
     depends_on:
       - defi-blockchain
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       -fortcanninghillheight=10
 
   defi-playground:
-    image: ghcr.io/defich/playground-api:2.28.2
+    image: ghcr.io/defich/playground-api:2.31.1
     depends_on:
       - defi-blockchain
     ports:
@@ -59,7 +59,7 @@ services:
       - "traefik.http.routers.playground.entrypoints=web"
 
   defi-whale:
-    image: ghcr.io/defich/whale:0.27.0
+    image: ghcr.io/defich/whale:0.31.2
     depends_on:
       - defi-blockchain
     ports:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@defichain/jellyfish-address": "^2.31.1",
     "@defichain/jellyfish-transaction": "^2.31.1",
-    "@defichain/playground-api-client": "^0.17.0",
+    "@defichain/playground-api-client": "^2.31.1",
     "@defichain/whale-api-client": "^0.31.2",
     "@headlessui/react": "^1.5.0",
     "@reduxjs/toolkit": "^1.8.0",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

With https://github.com/DeFiCh/wallet/pull/2325 merged in, we can consolidate the bumping workflow into one on Scan too.