### PR TITLE
`Transaction` Display pending transaction page with raw txn

### DIFF
--- a/cypress/integration/pages/transactions/RawTransaction.spec.ts
+++ b/cypress/integration/pages/transactions/RawTransaction.spec.ts
@@ -128,6 +128,6 @@ context('/transactions/[txid]?rawTx=[] on mobile', () => {
 
   it('should invalid raw transaction', function () {
     cy.visit('/transactions/invalidtxnid?rawtx=invalidrawtx')
-    cy.findAllByTestId('RawTransaction.not-found-banner').should('contain.text', 'The requested raw transaction could not be found.')
+    cy.findAllByTestId('RawTransaction.not-found-banner').should('contain.text', 'The requested transaction is either invalid or has yet to be confirmed. Please try again in a few minutes.')
   })
 })

--- a/cypress/integration/pages/transactions/RawTransaction.spec.ts
+++ b/cypress/integration/pages/transactions/RawTransaction.spec.ts
@@ -61,7 +61,7 @@ context('/transactions/[txid]?rawTx=[] on desktop', () => {
 
   it('should invalid raw transaction', function () {
     cy.visit('/transactions/invalidtxnid?rawtx=invalidrawtx')
-    cy.findAllByTestId('RawTransaction.not-found-banner').should('contain.text', 'The requested raw transaction could not be found.')
+    cy.findAllByTestId('RawTransaction.not-found-banner').should('contain.text', 'The requested transaction is either invalid or has yet to be confirmed. Please try again in a few minutes.')
   })
 })
 

--- a/cypress/integration/pages/transactions/RawTransaction.spec.ts
+++ b/cypress/integration/pages/transactions/RawTransaction.spec.ts
@@ -1,0 +1,75 @@
+context('/transactions/[txid]?rawTx=[] on desktop', () => {
+  before(() => {
+    cy.visit('/transactions/66109674cad41dbde99fcf687821b044b4610ba2921dfc1fd014b42320f8cf71?rawtx=04000000000101b0ed5e4ac2817af0018addd1d418b67654990e5ed5b6407c966f9266b0ee46680100000000ffffffff020000000000000000526a4c4f44665478691600145f787ab67fcbf179a9995b5dded40a0db62abc1c0f5cdddc09000000001600145f787ab67fcbf179a9995b5dded40a0db62abc1c000300000000000000a5e01a0000000000011100e0ba4c11000000001600145f787ab67fcbf179a9995b5dded40a0db62abc1c000247304402206e7025dc68f875df20d4de9aa6d25e8de96a6a4ae978b2cb365033d22ce70fa4022061a636fa90b1918d8b14fb3a378b5f9486debde04dd605fe3f945136fb5cb3d601210376893753c38b995acd841d5ea24165b4e1a41635cb7821cffa025e3b42ef5a2300000000')
+  })
+
+  beforeEach(() => {
+    cy.viewport('macbook-16')
+  })
+
+  it('should have RawTransaction Title', function () {
+    cy.findByTestId('RawTransaction.Title').should('have.text', 'Pending Transactions')
+  })
+
+  it('should have RawTransaction Total', function () {
+    cy.findByTestId('RawTransaction.total').should('contain.text', '2.90241248 DFI')
+  })
+
+  it('should RawTransaction Vin Index', function () {
+    cy.findByTestId('RawTransaction.VinIndex').should('have.text', '1')
+  })
+
+  it('should RawTransaction Vin Tx ID', function () {
+    cy.findByTestId('RawTransaction.VinTxId').should('have.text', '6846eeb066926f967c40b6d55e0e995476b618d4d1dd8a01f07a81c24a5eedb0')
+  })
+
+  it('should RawTransaction Vout token', function () {
+    cy.findAllByTestId('RawTransaction.VoutToken').eq(1).should('have.text', 'DFI')
+  })
+
+  it('should RawTransaction Vout Address', function () {
+    cy.findAllByTestId('RawTransaction.VoutAddress').eq(0).should('have.text', 'df1qtau84dnle0chn2vetdwaa4q2pkmz40qu4hqynw')
+  })
+
+  it('should RawTransaction Vout Value', function () {
+    cy.findAllByTestId('RawTransaction.VoutValue').eq(1).should('have.text', '2.90241248')
+  })
+})
+
+context('/transactions/[txid]?rawTx=[] on mobile', () => {
+  before(() => {
+    cy.visit('/transactions/66109674cad41dbde99fcf687821b044b4610ba2921dfc1fd014b42320f8cf71?rawtx=04000000000101b0ed5e4ac2817af0018addd1d418b67654990e5ed5b6407c966f9266b0ee46680100000000ffffffff020000000000000000526a4c4f44665478691600145f787ab67fcbf179a9995b5dded40a0db62abc1c0f5cdddc09000000001600145f787ab67fcbf179a9995b5dded40a0db62abc1c000300000000000000a5e01a0000000000011100e0ba4c11000000001600145f787ab67fcbf179a9995b5dded40a0db62abc1c000247304402206e7025dc68f875df20d4de9aa6d25e8de96a6a4ae978b2cb365033d22ce70fa4022061a636fa90b1918d8b14fb3a378b5f9486debde04dd605fe3f945136fb5cb3d601210376893753c38b995acd841d5ea24165b4e1a41635cb7821cffa025e3b42ef5a2300000000')
+  })
+
+  beforeEach(() => {
+    cy.viewport('iphone-x')
+  })
+
+  it('should have RawTransaction Title', function () {
+    cy.findByTestId('RawTransaction.Title').should('have.text', 'Pending Transactions')
+  })
+
+  it('should have RawTransaction Total', function () {
+    cy.findByTestId('RawTransaction.total').should('contain.text', '2.90241248 DFI')
+  })
+
+  it('should RawTransaction Vin Index', function () {
+    cy.findByTestId('RawTransaction.VinIndex').should('have.text', '1')
+  })
+
+  it('should RawTransaction Vin Tx ID', function () {
+    cy.findByTestId('RawTransaction.VinTxId').should('have.text', '6846eeb066926f967c40b6d55e0e995476b618d4d1dd8a01f07a81c24a5eedb0')
+  })
+
+  it('should RawTransaction Vout token', function () {
+    cy.findAllByTestId('RawTransaction.VoutToken').eq(1).should('have.text', 'DFI')
+  })
+
+  it('should RawTransaction Vout Address', function () {
+    cy.findAllByTestId('RawTransaction.VoutAddress').eq(0).should('have.text', 'df1qtau84dnle0chn2vetdwaa4q2pkmz40qu4hqynw')
+  })
+
+  it('should RawTransaction Vout Value', function () {
+    cy.findAllByTestId('RawTransaction.VoutValue').eq(1).should('have.text', '2.90241248')
+  })
+})

--- a/cypress/integration/pages/transactions/RawTransaction.spec.ts
+++ b/cypress/integration/pages/transactions/RawTransaction.spec.ts
@@ -1,6 +1,6 @@
 context('/transactions/[txid]?rawTx=[] on desktop', () => {
   before(() => {
-    cy.visit('/transactions/66109674cad41dbde99fcf687821b044b4610ba2921dfc1fd014b42320f8cf71?rawtx=04000000000101b0ed5e4ac2817af0018addd1d418b67654990e5ed5b6407c966f9266b0ee46680100000000ffffffff020000000000000000526a4c4f44665478691600145f787ab67fcbf179a9995b5dded40a0db62abc1c0f5cdddc09000000001600145f787ab67fcbf179a9995b5dded40a0db62abc1c000300000000000000a5e01a0000000000011100e0ba4c11000000001600145f787ab67fcbf179a9995b5dded40a0db62abc1c000247304402206e7025dc68f875df20d4de9aa6d25e8de96a6a4ae978b2cb365033d22ce70fa4022061a636fa90b1918d8b14fb3a378b5f9486debde04dd605fe3f945136fb5cb3d601210376893753c38b995acd841d5ea24165b4e1a41635cb7821cffa025e3b42ef5a2300000000')
+    cy.visit('/transactions/invalidtxnid?rawtx=04000000000101b0ed5e4ac2817af0018addd1d418b67654990e5ed5b6407c966f9266b0ee46680100000000ffffffff020000000000000000526a4c4f44665478691600145f787ab67fcbf179a9995b5dded40a0db62abc1c0f5cdddc09000000001600145f787ab67fcbf179a9995b5dded40a0db62abc1c000300000000000000a5e01a0000000000011100e0ba4c11000000001600145f787ab67fcbf179a9995b5dded40a0db62abc1c000247304402206e7025dc68f875df20d4de9aa6d25e8de96a6a4ae978b2cb365033d22ce70fa4022061a636fa90b1918d8b14fb3a378b5f9486debde04dd605fe3f945136fb5cb3d601210376893753c38b995acd841d5ea24165b4e1a41635cb7821cffa025e3b42ef5a2300000000')
   })
 
   beforeEach(() => {
@@ -8,37 +8,61 @@ context('/transactions/[txid]?rawTx=[] on desktop', () => {
   })
 
   it('should have RawTransaction Title', function () {
-    cy.findByTestId('RawTransaction.Title').should('have.text', 'Pending Transactions')
+    cy.findByTestId('RawTransaction.title').should('have.text', 'Transaction ID')
   })
 
-  it('should have RawTransaction Total', function () {
-    cy.findByTestId('RawTransaction.total').should('contain.text', '2.90241248 DFI')
+  it('should RawTransaction Pending Banner', function () {
+    cy.findByTestId('RawTransaction.pending-banner').should('contain.text', 'The requested transaction 6846eeb066926f967c40b6d55e0e995476b618d4d1dd8a01f07a81c24a5eedb0 is still pending, not all transaction information are currently available. Please wait for a few minutes for it to be confirmed.')
   })
 
-  it('should RawTransaction Vin Index', function () {
-    cy.findByTestId('RawTransaction.VinIndex').should('have.text', '1')
+  it('should RawTransaction details subtitle', function () {
+    cy.findByTestId('RawTransaction.details-subtitle').should('have.text', 'Details')
   })
 
-  it('should RawTransaction Vin Tx ID', function () {
-    cy.findByTestId('RawTransaction.VinTxId').should('have.text', '6846eeb066926f967c40b6d55e0e995476b618d4d1dd8a01f07a81c24a5eedb0')
+  it('should RawTransaction Details Left List', function () {
+    cy.findAllByTestId('RawTransaction.DetailsLeft.List').eq(0).should('contain.text', 'N/A')
   })
 
-  it('should RawTransaction Vout token', function () {
-    cy.findAllByTestId('RawTransaction.VoutToken').eq(1).should('have.text', 'DFI')
+  it('should RawTransaction Details Right List', function () {
+    cy.findAllByTestId('RawTransaction.DetailsRight.List').eq(0).should('contain.text', 'OP_DEFI_TX_COMPOSITE_SWAP')
   })
 
-  it('should RawTransaction Vout Address', function () {
-    cy.findAllByTestId('RawTransaction.VoutAddress').eq(0).should('have.text', 'df1qtau84dnle0chn2vetdwaa4q2pkmz40qu4hqynw')
+  it('should RawTransaction Details Right List', function () {
+    cy.findAllByTestId('RawTransaction.DetailsRight.List').eq(0).should('contain.text', '2.90241248')
   })
 
-  it('should RawTransaction Vout Value', function () {
-    cy.findAllByTestId('RawTransaction.VoutValue').eq(1).should('have.text', '2.90241248')
+  it('should RawTransaction DetailsSummary total', function () {
+    cy.findAllByTestId('RawTransaction.DetailsSummary.total').eq(0).should('contain.text', '2.90241248')
+  })
+
+  it('should DfTxCompositeSwap Swap From Title', function () {
+    cy.findAllByTestId('DfTxCompositeSwap.SwapFromTitle').should('contain.text', 'Swap From')
+  })
+
+  it('should DfTxCompositeSwap Swap To Title', function () {
+    cy.findAllByTestId('DfTxCompositeSwap.SwapToTitle').should('contain.text', 'Swap To')
+  })
+
+  it('should DfTxCompositeSwap Details From Address', function () {
+    cy.findAllByTestId('DfTxCompositeSwap.FromAddress').should('contain.text', 'df1qtau84dnle0chn2vetdwaa4q2pkmz40qu4hqynw')
+  })
+
+  it('should DfTxCompositeSwap To Address', function () {
+    cy.findAllByTestId('DfTxCompositeSwap.ToAddress').should('contain.text', 'df1qtau84dnle0chn2vetdwaa4q2pkmz40qu4hqynw')
+  })
+
+  it('should DfTxCompositeSwap From Amount', function () {
+    cy.findAllByTestId('DfTxCompositeSwap.FromAmount').should('contain.text', '1.65469532')
+  })
+
+  it('should DfTxCompositeSwap Max Price', function () {
+    cy.findAllByTestId('DfTxCompositeSwap.MaxPrice').should('contain.text', '3.01761445')
   })
 })
 
 context('/transactions/[txid]?rawTx=[] on mobile', () => {
   before(() => {
-    cy.visit('/transactions/66109674cad41dbde99fcf687821b044b4610ba2921dfc1fd014b42320f8cf71?rawtx=04000000000101b0ed5e4ac2817af0018addd1d418b67654990e5ed5b6407c966f9266b0ee46680100000000ffffffff020000000000000000526a4c4f44665478691600145f787ab67fcbf179a9995b5dded40a0db62abc1c0f5cdddc09000000001600145f787ab67fcbf179a9995b5dded40a0db62abc1c000300000000000000a5e01a0000000000011100e0ba4c11000000001600145f787ab67fcbf179a9995b5dded40a0db62abc1c000247304402206e7025dc68f875df20d4de9aa6d25e8de96a6a4ae978b2cb365033d22ce70fa4022061a636fa90b1918d8b14fb3a378b5f9486debde04dd605fe3f945136fb5cb3d601210376893753c38b995acd841d5ea24165b4e1a41635cb7821cffa025e3b42ef5a2300000000')
+    cy.visit('/transactions/invalidtxnid?rawtx=04000000000101b0ed5e4ac2817af0018addd1d418b67654990e5ed5b6407c966f9266b0ee46680100000000ffffffff020000000000000000526a4c4f44665478691600145f787ab67fcbf179a9995b5dded40a0db62abc1c0f5cdddc09000000001600145f787ab67fcbf179a9995b5dded40a0db62abc1c000300000000000000a5e01a0000000000011100e0ba4c11000000001600145f787ab67fcbf179a9995b5dded40a0db62abc1c000247304402206e7025dc68f875df20d4de9aa6d25e8de96a6a4ae978b2cb365033d22ce70fa4022061a636fa90b1918d8b14fb3a378b5f9486debde04dd605fe3f945136fb5cb3d601210376893753c38b995acd841d5ea24165b4e1a41635cb7821cffa025e3b42ef5a2300000000')
   })
 
   beforeEach(() => {
@@ -46,30 +70,54 @@ context('/transactions/[txid]?rawTx=[] on mobile', () => {
   })
 
   it('should have RawTransaction Title', function () {
-    cy.findByTestId('RawTransaction.Title').should('have.text', 'Pending Transactions')
+    cy.findByTestId('RawTransaction.title').should('have.text', 'Transaction ID')
   })
 
-  it('should have RawTransaction Total', function () {
-    cy.findByTestId('RawTransaction.total').should('contain.text', '2.90241248 DFI')
+  it('should RawTransaction Pending Banner', function () {
+    cy.findByTestId('RawTransaction.pending-banner').should('contain.text', 'The requested transaction 6846eeb066926f967c40b6d55e0e995476b618d4d1dd8a01f07a81c24a5eedb0 is still pending, not all transaction information are currently available. Please wait for a few minutes for it to be confirmed.')
   })
 
-  it('should RawTransaction Vin Index', function () {
-    cy.findByTestId('RawTransaction.VinIndex').should('have.text', '1')
+  it('should RawTransaction details subtitle', function () {
+    cy.findByTestId('RawTransaction.details-subtitle').should('have.text', 'Details')
   })
 
-  it('should RawTransaction Vin Tx ID', function () {
-    cy.findByTestId('RawTransaction.VinTxId').should('have.text', '6846eeb066926f967c40b6d55e0e995476b618d4d1dd8a01f07a81c24a5eedb0')
+  it('should RawTransaction Details Left List', function () {
+    cy.findAllByTestId('RawTransaction.DetailsLeft.List').eq(0).should('contain.text', 'N/A')
   })
 
-  it('should RawTransaction Vout token', function () {
-    cy.findAllByTestId('RawTransaction.VoutToken').eq(1).should('have.text', 'DFI')
+  it('should RawTransaction Details Right List', function () {
+    cy.findAllByTestId('RawTransaction.DetailsRight.List').eq(0).should('contain.text', 'OP_DEFI_TX_COMPOSITE_SWAP')
   })
 
-  it('should RawTransaction Vout Address', function () {
-    cy.findAllByTestId('RawTransaction.VoutAddress').eq(0).should('have.text', 'df1qtau84dnle0chn2vetdwaa4q2pkmz40qu4hqynw')
+  it('should RawTransaction Details Right List', function () {
+    cy.findAllByTestId('RawTransaction.DetailsRight.List').eq(0).should('contain.text', '2.90241248')
   })
 
-  it('should RawTransaction Vout Value', function () {
-    cy.findAllByTestId('RawTransaction.VoutValue').eq(1).should('have.text', '2.90241248')
+  it('should RawTransaction DetailsSummary total', function () {
+    cy.findAllByTestId('RawTransaction.DetailsSummary.total').eq(0).should('contain.text', '2.90241248')
+  })
+
+  it('should DfTxCompositeSwap Swap From Title', function () {
+    cy.findAllByTestId('DfTxCompositeSwap.SwapFromTitle').should('contain.text', 'Swap From')
+  })
+
+  it('should DfTxCompositeSwap Swap To Title', function () {
+    cy.findAllByTestId('DfTxCompositeSwap.SwapToTitle').should('contain.text', 'Swap To')
+  })
+
+  it('should DfTxCompositeSwap Details From Address', function () {
+    cy.findAllByTestId('DfTxCompositeSwap.FromAddress').should('contain.text', 'df1qtau84dnle0chn2vetdwaa4q2pkmz40qu4hqynw')
+  })
+
+  it('should DfTxCompositeSwap To Address', function () {
+    cy.findAllByTestId('DfTxCompositeSwap.ToAddress').should('contain.text', 'df1qtau84dnle0chn2vetdwaa4q2pkmz40qu4hqynw')
+  })
+
+  it('should DfTxCompositeSwap From Amount', function () {
+    cy.findAllByTestId('DfTxCompositeSwap.FromAmount').should('contain.text', '1.65469532')
+  })
+
+  it('should DfTxCompositeSwap Max Price', function () {
+    cy.findAllByTestId('DfTxCompositeSwap.MaxPrice').should('contain.text', '3.01761445')
   })
 })

--- a/cypress/integration/pages/transactions/RawTransaction.spec.ts
+++ b/cypress/integration/pages/transactions/RawTransaction.spec.ts
@@ -58,6 +58,11 @@ context('/transactions/[txid]?rawTx=[] on desktop', () => {
   it('should DfTxCompositeSwap Max Price', function () {
     cy.findAllByTestId('DfTxCompositeSwap.MaxPrice').should('contain.text', '3.01761445')
   })
+
+  it('should invalid raw transaction', function () {
+    cy.visit('/transactions/invalidtxnid?rawtx=invalidrawtx')
+    cy.findAllByTestId('RawTransaction.not-found-banner').should('contain.text', 'The requested raw transaction could not be found.')
+  })
 })
 
 context('/transactions/[txid]?rawTx=[] on mobile', () => {
@@ -119,5 +124,10 @@ context('/transactions/[txid]?rawTx=[] on mobile', () => {
 
   it('should DfTxCompositeSwap Max Price', function () {
     cy.findAllByTestId('DfTxCompositeSwap.MaxPrice').should('contain.text', '3.01761445')
+  })
+
+  it('should invalid raw transaction', function () {
+    cy.visit('/transactions/invalidtxnid?rawtx=invalidrawtx')
+    cy.findAllByTestId('RawTransaction.not-found-banner').should('contain.text', 'The requested raw transaction could not be found.')
   })
 })

--- a/src/pages/transactions/[txid].page.tsx
+++ b/src/pages/transactions/[txid].page.tsx
@@ -27,10 +27,8 @@ interface TransactionPageProps {
 export default function TransactionPage (props: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element {
   const router = useRouter()
 
-  // TODO (nichellekoh) : update txn pending logic once tested
-  // const transactionPending = props.transaction === undefined || props.vins === undefined || props.vouts === undefined
-
-  if (router.query.rawtx !== undefined) { // && transactionPending) {
+  const transactionPending = props.transaction === undefined || props.vins === undefined || props.vouts === undefined
+  if (router.query.rawtx !== undefined && transactionPending) {
     return (
       <Container className='pt-12 pb-20'>
         <RawTransaction

--- a/src/pages/transactions/[txid].page.tsx
+++ b/src/pages/transactions/[txid].page.tsx
@@ -3,7 +3,10 @@ import { Transaction, TransactionVin, TransactionVout } from '@defichain/whale-a
 import { getWhaleApiClient } from '@contexts/WhaleContext'
 import { Container } from '@components/commons/Container'
 import BigNumber from 'bignumber.js'
-import { TransactionHeading, TransactionNotFoundHeading } from './_components/TransactionHeadings'
+import {
+  TransactionHeading,
+  TransactionNotFoundHeading
+} from './_components/TransactionHeadings'
 import { TransactionVinVout } from './_components/TransactionVinVout'
 import { TransactionSummaryTable } from './_components/TransactionSummaryTable'
 import { TransactionDfTx } from './_components/TransactionDfTx'
@@ -11,6 +14,8 @@ import { SmartBuffer } from 'smart-buffer'
 import { AccountToUtxos, CAccountToUtxos, DfTx, OP_DEFI_TX, toOPCodes } from '@defichain/jellyfish-transaction'
 import { isAlphanumeric } from '../../utils/commons/StringValidator'
 import { Head } from '@components/commons/Head'
+import { useRouter } from 'next/router'
+import { RawTransaction } from './_components/RawTransaction'
 
 interface TransactionPageProps {
   txid: string
@@ -20,6 +25,21 @@ interface TransactionPageProps {
 }
 
 export default function TransactionPage (props: InferGetServerSidePropsType<typeof getServerSideProps>): JSX.Element {
+  const router = useRouter()
+
+  // TODO (nichellekoh) : update txn pending logic once tested
+  // const transactionPending = props.transaction === undefined || props.vins === undefined || props.vouts === undefined
+
+  if (router.query.rawtx !== undefined) { // && transactionPending) {
+    return (
+      <Container className='pt-12 pb-20'>
+        <RawTransaction
+          rawTx={router.query.rawtx as string}
+        />
+      </Container>
+    )
+  }
+
   if (props.transaction === undefined || props.vins === undefined || props.vouts === undefined) {
     return (
       <Container className='pt-12 pb-20'>

--- a/src/pages/transactions/_components/RawTransaction.tsx
+++ b/src/pages/transactions/_components/RawTransaction.tsx
@@ -1,0 +1,61 @@
+import {
+  CTransaction,
+  CTransactionSegWit,
+  DfTx, OP_DEFI_TX,
+  Transaction,
+  TransactionSegWit,
+  Vout
+} from '@defichain/jellyfish-transaction'
+import { SmartBuffer } from 'smart-buffer'
+import { Container } from '@components/commons/Container'
+import { RawTransactionHeading } from './RawTransactionHeadings'
+import { RawTransactionVinVout } from './RawTransactionVinVout'
+import { TransactionDfTx } from './TransactionDfTx'
+
+export function RawTransaction ({ rawTx }: { rawTx: string }): JSX.Element {
+  let transaction: TransactionSegWit | Transaction | undefined
+
+  if (rawTx !== undefined) {
+    const buffer = SmartBuffer.fromBuffer(Buffer.from(rawTx, 'hex'))
+    try {
+      if (rawTx.startsWith('040000000001')) {
+        transaction = new CTransactionSegWit(buffer)
+      } else {
+        transaction = new CTransaction(buffer)
+      }
+    } catch (e) {
+      transaction = undefined
+    }
+  }
+
+  if (transaction === undefined) {
+    return (
+      <Container className='pt-12 pb-20'>
+        <div className='bg-red-100 rounded p-3 text-center' data-testid='transaction-not-found-banner'>
+          The requested raw transaction could not be found.
+        </div>
+      </Container>
+    )
+  }
+
+  const vouts = transaction.vout
+  const vins = transaction.vin
+  const dftx: DfTx<any> | undefined = getDfTx(vouts)
+  console.log(vins[0].script.stack)
+
+  return (
+    <>
+      <RawTransactionHeading transaction={transaction} />
+      <RawTransactionVinVout transaction={transaction} vins={vins} vouts={vouts} dftxName={dftx?.name} />
+      <TransactionDfTx dftx={dftx} />
+    </>
+  )
+}
+
+function getDfTx (vouts: Vout[]): DfTx<any> | undefined {
+  const stack = vouts[0].script.stack
+  if (stack.length !== 2 || stack[1].type !== 'OP_DEFI_TX') {
+    return undefined
+  }
+  return (stack[1] as OP_DEFI_TX).tx
+}

--- a/src/pages/transactions/_components/RawTransaction.tsx
+++ b/src/pages/transactions/_components/RawTransaction.tsx
@@ -14,6 +14,13 @@ import { TransactionDfTx } from './TransactionDfTx'
 
 export function RawTransaction ({ rawTx }: { rawTx: string }): JSX.Element {
   let transaction: TransactionSegWit | Transaction | undefined
+  
+    useEffect(() => {
+    const interval = setInterval(() => {
+      location.reload()
+    }, 15000)
+    return () => clearInterval(interval)
+  }, [])
 
   if (rawTx !== undefined) {
     const buffer = SmartBuffer.fromBuffer(Buffer.from(rawTx, 'hex'))
@@ -32,7 +39,7 @@ export function RawTransaction ({ rawTx }: { rawTx: string }): JSX.Element {
     return (
       <Container className='pt-12 pb-20'>
         <div className='bg-red-100 rounded p-3 text-center' data-testid='RawTransaction.not-found-banner'>
-          The requested raw transaction could not be found.
+          The requested transaction is either invalid or has yet to be confirmed. Please try again in a few minutes.
         </div>
       </Container>
     )

--- a/src/pages/transactions/_components/RawTransaction.tsx
+++ b/src/pages/transactions/_components/RawTransaction.tsx
@@ -11,11 +11,12 @@ import { Container } from '@components/commons/Container'
 import { RawTransactionHeading } from './RawTransactionHeadings'
 import { RawTransactionVinVout } from './RawTransactionVinVout'
 import { TransactionDfTx } from './TransactionDfTx'
+import { useEffect } from 'react'
 
 export function RawTransaction ({ rawTx }: { rawTx: string }): JSX.Element {
   let transaction: TransactionSegWit | Transaction | undefined
-  
-    useEffect(() => {
+
+  useEffect(() => {
     const interval = setInterval(() => {
       location.reload()
     }, 15000)

--- a/src/pages/transactions/_components/RawTransaction.tsx
+++ b/src/pages/transactions/_components/RawTransaction.tsx
@@ -31,7 +31,7 @@ export function RawTransaction ({ rawTx }: { rawTx: string }): JSX.Element {
   if (transaction === undefined) {
     return (
       <Container className='pt-12 pb-20'>
-        <div className='bg-red-100 rounded p-3 text-center' data-testid='transaction-not-found-banner'>
+        <div className='bg-red-100 rounded p-3 text-center' data-testid='RawTransaction.not-found-banner'>
           The requested raw transaction could not be found.
         </div>
       </Container>
@@ -41,8 +41,6 @@ export function RawTransaction ({ rawTx }: { rawTx: string }): JSX.Element {
   const vouts = transaction.vout
   const vins = transaction.vin
   const dftx: DfTx<any> | undefined = getDfTx(vouts)
-  console.log(vins[0].script.stack)
-
   return (
     <>
       <RawTransactionHeading transaction={transaction} />

--- a/src/pages/transactions/_components/RawTransactionHeadings.tsx
+++ b/src/pages/transactions/_components/RawTransactionHeadings.tsx
@@ -22,7 +22,6 @@ export function RawTransactionHeading (props: RawTransactionHeadingProps): JSX.E
 }
 
 function RawTransactionPendingHeading (props: { txid: string }): JSX.Element {
-
   return (
     <div className='bg-red-100 rounded p-3 text-center mb-5' data-testid='RawTransaction.pending-banner'>
       The requested transaction <code className='break-all'>{props.txid}</code> is still pending, not all transaction information are currently available.

--- a/src/pages/transactions/_components/RawTransactionHeadings.tsx
+++ b/src/pages/transactions/_components/RawTransactionHeadings.tsx
@@ -1,0 +1,36 @@
+import { CopyButton } from '@components/commons/CopyButton'
+import { Transaction, TransactionSegWit } from '@defichain/jellyfish-transaction'
+
+interface RawTransactionHeadingProps {
+  transaction: TransactionSegWit | Transaction | undefined
+}
+
+interface RawTransactionPendingHeadingProps {
+  txid: string
+}
+
+export function RawTransactionHeading (props: RawTransactionHeadingProps): JSX.Element {
+  const txid = props.transaction?.vin[0].txid ?? ''
+  return (
+    <>
+      <RawTransactionPendingHeading txid={txid} />
+      <span className='leading-6 opacity-60' data-testid='title'>
+        Transaction ID
+      </span>
+      <div className='flex items-center mt-1'>
+        <h1 className='text-2xl font-medium break-all' data-testid='transaction-txid'>{txid}</h1>
+        <CopyButton className='ml-2' content={txid} />
+      </div>
+    </>
+  )
+}
+
+function RawTransactionPendingHeading (props: RawTransactionPendingHeadingProps): JSX.Element {
+  const txid = props.txid
+
+  return (
+    <div className='bg-red-100 rounded p-3 text-center mb-5' data-testid='transaction-pending-banner'>
+      The requested transaction <code className='break-all'>{txid}</code> is still pending, please wait for a few minutes for it to be confirmed.
+    </div>
+  )
+}

--- a/src/pages/transactions/_components/RawTransactionHeadings.tsx
+++ b/src/pages/transactions/_components/RawTransactionHeadings.tsx
@@ -30,7 +30,8 @@ function RawTransactionPendingHeading (props: RawTransactionPendingHeadingProps)
 
   return (
     <div className='bg-red-100 rounded p-3 text-center mb-5' data-testid='transaction-pending-banner'>
-      The requested transaction <code className='break-all'>{txid}</code> is still pending, please wait for a few minutes for it to be confirmed.
+      The requested transaction <code className='break-all'>{txid}</code> is still pending, not all transaction information are currently available.
+      Please wait for a few minutes for it to be confirmed.
     </div>
   )
 }

--- a/src/pages/transactions/_components/RawTransactionHeadings.tsx
+++ b/src/pages/transactions/_components/RawTransactionHeadings.tsx
@@ -5,10 +5,6 @@ interface RawTransactionHeadingProps {
   transaction: TransactionSegWit | Transaction | undefined
 }
 
-interface RawTransactionPendingHeadingProps {
-  txid: string
-}
-
 export function RawTransactionHeading (props: RawTransactionHeadingProps): JSX.Element {
   const txid = props.transaction?.vin[0].txid ?? ''
   return (
@@ -25,12 +21,11 @@ export function RawTransactionHeading (props: RawTransactionHeadingProps): JSX.E
   )
 }
 
-function RawTransactionPendingHeading (props: RawTransactionPendingHeadingProps): JSX.Element {
-  const txid = props.txid
+function RawTransactionPendingHeading (props: { txid: string }): JSX.Element {
 
   return (
     <div className='bg-red-100 rounded p-3 text-center mb-5' data-testid='RawTransaction.pending-banner'>
-      The requested transaction <code className='break-all'>{txid}</code> is still pending, not all transaction information are currently available.
+      The requested transaction <code className='break-all'>{props.txid}</code> is still pending, not all transaction information are currently available.
       Please wait for a few minutes for it to be confirmed.
     </div>
   )

--- a/src/pages/transactions/_components/RawTransactionHeadings.tsx
+++ b/src/pages/transactions/_components/RawTransactionHeadings.tsx
@@ -14,11 +14,11 @@ export function RawTransactionHeading (props: RawTransactionHeadingProps): JSX.E
   return (
     <>
       <RawTransactionPendingHeading txid={txid} />
-      <span className='leading-6 opacity-60' data-testid='title'>
+      <span className='leading-6 opacity-60' data-testid='RawTransaction.title'>
         Transaction ID
       </span>
       <div className='flex items-center mt-1'>
-        <h1 className='text-2xl font-medium break-all' data-testid='transaction-txid'>{txid}</h1>
+        <h1 className='text-2xl font-medium break-all' data-testid='RawTransaction.txid'>{txid}</h1>
         <CopyButton className='ml-2' content={txid} />
       </div>
     </>
@@ -29,7 +29,7 @@ function RawTransactionPendingHeading (props: RawTransactionPendingHeadingProps)
   const txid = props.txid
 
   return (
-    <div className='bg-red-100 rounded p-3 text-center mb-5' data-testid='transaction-pending-banner'>
+    <div className='bg-red-100 rounded p-3 text-center mb-5' data-testid='RawTransaction.pending-banner'>
       The requested transaction <code className='break-all'>{txid}</code> is still pending, not all transaction information are currently available.
       Please wait for a few minutes for it to be confirmed.
     </div>

--- a/src/pages/transactions/_components/RawTransactionVinVout.tsx
+++ b/src/pages/transactions/_components/RawTransactionVinVout.tsx
@@ -21,13 +21,12 @@ export function RawTransactionVinVout (props: RawTransactionVinVoutProps): JSX.E
       <div className='mt-5 flex flex-col space-y-6 items-start lg:flex-row lg:space-x-8 lg:space-y-0'>
         <div className='w-full lg:w-1/2'>
           <div className='flex flex-col space-y-1' data-testid='TransactionDetailsLeft.List'>
-            {props.vins.map((vin, index) => {
+            {props.vins.map((vin) => {
               const decoded = vin.script !== undefined ? fromScript(vin.script, network) : undefined
-              console.log(decoded)
               return (
                 <TransactionVectorRow
                   label='INPUT'
-                  address={decoded?.address ?? ''}
+                  address={decoded?.address ?? 'N/A'}
                   value=''
                   key={vin.txid}
                   network={network}

--- a/src/pages/transactions/_components/RawTransactionVinVout.tsx
+++ b/src/pages/transactions/_components/RawTransactionVinVout.tsx
@@ -1,0 +1,87 @@
+import { useNetwork } from '@contexts/NetworkContext'
+import { IoArrowForwardOutline } from 'react-icons/io5'
+import { fromScript } from '@defichain/jellyfish-address'
+import BigNumber from 'bignumber.js'
+import { TransactionVectorRow } from '@components/commons/transactions/TransactionVectorRow'
+import { Transaction, TransactionSegWit, Vin, Vout } from '@defichain/jellyfish-transaction'
+
+interface RawTransactionVinVoutProps {
+  transaction: Transaction | TransactionSegWit
+  vins: Vin[]
+  vouts: Vout[]
+  dftxName?: string
+}
+
+export function RawTransactionVinVout (props: RawTransactionVinVoutProps): JSX.Element {
+  const network = useNetwork().name
+
+  return (
+    <>
+      <h1 className='font-medium text-2xl mt-6' data-testid='details-subtitle'>Details</h1>
+      <div className='mt-5 flex flex-col space-y-6 items-start lg:flex-row lg:space-x-8 lg:space-y-0'>
+        <div className='w-full lg:w-1/2'>
+          <div className='flex flex-col space-y-1' data-testid='TransactionDetailsLeft.List'>
+            {props.vins.map((vin, index) => {
+              const decoded = vin.script !== undefined ? fromScript(vin.script, network) : undefined
+              console.log(decoded)
+              return (
+                <TransactionVectorRow
+                  label='INPUT'
+                  address={decoded?.address ?? ''}
+                  value=''
+                  key={vin.txid}
+                  network={network}
+                  isAddressClickable={false}
+                />
+              )
+            })}
+          </div>
+        </div>
+
+        <div className='flex items-center justify-center text-gray-600 w-full lg:w-auto lg:h-20'>
+          <IoArrowForwardOutline className='transform rotate-90 lg:rotate-0' size={24} />
+        </div>
+
+        <div className='w-full lg:w-1/2'>
+          <div className='flex flex-col space-y-1' data-testid='TransactionDetailsRight.List'>
+            {props.vouts.map((vout, index) => {
+              const decoded = vout.script !== undefined ? fromScript(vout.script, network) : undefined
+
+              let address = decoded?.address ?? 'N/A'
+              if (index === 0) {
+                address = decoded?.address ?? props.dftxName ?? 'N/A'
+              }
+              return (
+                <TransactionVectorRow
+                  label='OUTPUT'
+                  address={address}
+                  value={`${vout.value.toFixed(8)} DFI`}
+                  key={vout.tokenId}
+                  network={network}
+                  isAddressClickable={decoded?.address !== undefined}
+                />
+              )
+            })}
+          </div>
+        </div>
+      </div>
+
+      <div className='flex flex-col items-end justify-between mt-8'>
+        <div className='flex justify-between space-x-3 mt-2' data-testid='TransactionDetailsSummary.total'>
+          <span>Total:</span>
+          <span>{getTotalVoutValue(props.vouts)} DFI</span>
+        </div>
+      </div>
+    </>
+  )
+}
+
+function getTotalVoutValue (vouts: Vout[] | undefined): string {
+  let value: BigNumber = new BigNumber(0)
+  if (vouts !== undefined) {
+    vouts.forEach(vout => {
+      value = new BigNumber(vout.value).plus(value)
+    })
+  }
+  return value.toFixed(8)
+}

--- a/src/pages/transactions/_components/RawTransactionVinVout.tsx
+++ b/src/pages/transactions/_components/RawTransactionVinVout.tsx
@@ -17,10 +17,10 @@ export function RawTransactionVinVout (props: RawTransactionVinVoutProps): JSX.E
 
   return (
     <>
-      <h1 className='font-medium text-2xl mt-6' data-testid='details-subtitle'>Details</h1>
+      <h1 className='font-medium text-2xl mt-6' data-testid='RawTransaction.details-subtitle'>Details</h1>
       <div className='mt-5 flex flex-col space-y-6 items-start lg:flex-row lg:space-x-8 lg:space-y-0'>
         <div className='w-full lg:w-1/2'>
-          <div className='flex flex-col space-y-1' data-testid='TransactionDetailsLeft.List'>
+          <div className='flex flex-col space-y-1' data-testid='RawTransaction.DetailsLeft.List'>
             {props.vins.map((vin) => {
               const decoded = vin.script !== undefined ? fromScript(vin.script, network) : undefined
               return (
@@ -42,7 +42,7 @@ export function RawTransactionVinVout (props: RawTransactionVinVoutProps): JSX.E
         </div>
 
         <div className='w-full lg:w-1/2'>
-          <div className='flex flex-col space-y-1' data-testid='TransactionDetailsRight.List'>
+          <div className='flex flex-col space-y-1' data-testid='RawTransaction.DetailsRight.List'>
             {props.vouts.map((vout, index) => {
               const decoded = vout.script !== undefined ? fromScript(vout.script, network) : undefined
 
@@ -66,7 +66,7 @@ export function RawTransactionVinVout (props: RawTransactionVinVoutProps): JSX.E
       </div>
 
       <div className='flex flex-col items-end justify-between mt-8'>
-        <div className='flex justify-between space-x-3 mt-2' data-testid='TransactionDetailsSummary.total'>
+        <div className='flex justify-between space-x-3 mt-2' data-testid='RawTransaction.DetailsSummary.total'>
           <span>Total:</span>
           <span>{getTotalVoutValue(props.vouts)} DFI</span>
         </div>

--- a/src/pages/transactions/_components/RawTransactionVinVout.tsx
+++ b/src/pages/transactions/_components/RawTransactionVinVout.tsx
@@ -55,7 +55,7 @@ export function RawTransactionVinVout (props: RawTransactionVinVoutProps): JSX.E
                   label='OUTPUT'
                   address={address}
                   value={`${vout.value.toFixed(8)} DFI`}
-                  key={vout.tokenId}
+                  key={index}
                   network={network}
                   isAddressClickable={decoded?.address !== undefined}
                 />


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:
Currently, when transaction is still pending, no information is shown. With this, user will be able to view some information of the pending transaction (redirected from LW) 

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/DeFiCh/scan/issues/590

Build on top of https://github.com/DeFiCh/scan/pull/769

#### Sample Links & Screenshots:
<!--
(Optional) Provide a link to changes made using Netlify Preview deployment.
-->
Link: 
<details>
<summary>Desktop Screenshot</summary>

![Screenshot 2022-04-08 at 6 16 48 PM](https://user-images.githubusercontent.com/8347352/162416259-ccd756aa-1968-47f2-8a39-bbf1b700ffec.png)


<!-- Image has to be between break lines -->

</details>
<details>
<summary>Mobile Screenshot</summary> 

![Screenshot 2022-04-08 at 6 15 18 PM](https://user-images.githubusercontent.com/8347352/162416065-e5ddd24a-d393-4159-9ceb-b7883eec3fdc.png)

![Screenshot 2022-04-08 at 6 15 25 PM](https://user-images.githubusercontent.com/8347352/162416068-8412b151-0e79-4916-99fb-e2ae1e1080a8.png)

<!-- Image has to be between break lines -->

</details>

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [x] Tested on multiple web browsers
- [x] Tested responsiveness (e.g, iPhone, iPad, Desktop)
- [x] No console errors
- [x] Unit tests*
- [x] Added e2e tests*

<!-- 
* If applicable 
-->
