### PR TITLE
chore(countdown): Updated countdown logic

### DIFF
--- a/src/pages/blocks/countdown/[query]/_components/CountdownSection.tsx
+++ b/src/pages/blocks/countdown/[query]/_components/CountdownSection.tsx
@@ -1,11 +1,18 @@
 import React from 'react'
 import { InfoHoverPopover } from '@components/commons/popover/InfoHoverPopover'
 
-export function CountdownSection (props: { timeLeftSecs: number }): JSX.Element {
-  const days = Math.floor(props.timeLeftSecs / (3600 * 24))
-  const hours = Math.floor((props.timeLeftSecs - days * (3600 * 24)) / 3600)
-  const mins = Math.floor((props.timeLeftSecs - days * (3600 * 24) - hours * 3600) / 60)
-  const secs = props.timeLeftSecs - (days * (3600 * 24)) - (hours * 3600) - (mins * 60)
+export function CountdownSection (props: { timeLeftSecs: number, estimatedTargetTime: number }): JSX.Element {
+  let days = Math.floor(props.timeLeftSecs / (3600 * 24))
+  let hours = Math.floor((props.timeLeftSecs - days * (3600 * 24)) / 3600)
+  let mins = Math.floor((props.timeLeftSecs - days * (3600 * 24) - hours * 3600) / 60)
+  let secs = props.timeLeftSecs - (days * (3600 * 24)) - (hours * 3600) - (mins * 60)
+
+  if (props.timeLeftSecs <= 0) {
+    days = 0
+    hours = 0
+    mins = 0
+    secs = 0
+  }
 
   return (
     <div className='flex flex-wrap justify-center -m-2 mt-8'>
@@ -17,9 +24,13 @@ export function CountdownSection (props: { timeLeftSecs: number }): JSX.Element 
       <div className='w-full flex items-center lg:w-4/6 mt-2 md:mt-0 px-0.5 md:px-2 text-sm'>
         <span className='text-gray-500'>Estimated Target Date:</span>
         <span className='ml-1 text-gray-900 font-medium'>
-          {new Date(new Date().getTime() + props.timeLeftSecs * 1000).toString()}
+          {new Date(props.estimatedTargetTime).toString()}
         </span>
-        <InfoHoverPopover className='ml-1 self-center' description='Estimated based on the number of blocks remaining.' placement='bottom' />
+        <InfoHoverPopover
+          className='ml-1 self-center'
+          description={'Estimated based on the number of blocks remaining and from the current block\'s median time.'}
+          placement='bottom'
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Updated countdown logic to be deterministic based on the current block's median time.

Caveats: There may be occurrences where the target block is too close to the current block. The countdown will only show 0's as the targetted time has already past. Etherscan shares the same "issue".