### PR TITLE
feature(dex): display stab fees on usdc,usdt pair

### DIFF
--- a/src/pages/dex/[poolpairId]/_components/PoolPairDexStabilizationFee.tsx
+++ b/src/pages/dex/[poolpairId]/_components/PoolPairDexStabilizationFee.tsx
@@ -2,7 +2,11 @@ import ReactNumberFormat from 'react-number-format'
 import BigNumber from 'bignumber.js'
 import { InfoHoverPopover } from '@components/commons/popover/InfoHoverPopover'
 
-export function PoolPairDexStabilizationFee (props: { fee: string }): JSX.Element {
+export function PoolPairDexStabilizationFee (props: { fee: string | undefined }): JSX.Element {
+  if (props.fee === undefined) {
+    return <></>
+  }
+
   return (
     <div className='flex flex-wrap flex-row w-full lg:w-fit mt-2 lg:mt-8 p-4 lg:p-6 rounded-lg border border-gray-200 justify-between items-center dark:border-gray-700 dark:bg-gray-800' data-testid='PoolPairDexStabilizationFee'>
       <div className='flex items-center mr-4 lg:mr-8'>

--- a/src/pages/dex/[poolpairId]/index.page.tsx
+++ b/src/pages/dex/[poolpairId]/index.page.tsx
@@ -71,7 +71,7 @@ export default function PoolPairPage (props: InferGetServerSidePropsType<typeof 
         />
         <div className='flex flex-wrap flex-row lg:space-x-4'>
           <PoolPairDetailsBar poolpair={poolpairs} />
-          {poolpairs.displaySymbol === 'DUSD-DFI' && poolpairs.tokenA.fee?.pct !== undefined &&
+          {['DUSD-DFI', 'dUSDC-DFI', 'dUSDT-DFI'].includes(poolpairs.displaySymbol) && poolpairs.tokenA.fee?.pct !== undefined &&
             <PoolPairDexStabilizationFee fee={poolpairs.tokenA.fee.pct} />}
         </div>
         <div className='flex flex-wrap space-y-12 lg:space-y-0 lg:flex-nowrap mt-8'>

--- a/src/pages/dex/[poolpairId]/index.page.tsx
+++ b/src/pages/dex/[poolpairId]/index.page.tsx
@@ -71,7 +71,7 @@ export default function PoolPairPage (props: InferGetServerSidePropsType<typeof 
         />
         <div className='flex flex-wrap flex-row lg:space-x-4'>
           <PoolPairDetailsBar poolpair={poolpairs} />
-          {['DUSD-DFI', 'dUSDC-DFI', 'dUSDT-DFI'].includes(poolpairs.displaySymbol) && poolpairs.tokenA.fee?.pct !== undefined &&
+          {['DUSD-DFI', 'dUSDC-DUSD', 'dUSDT-DUSD'].includes(poolpairs.displaySymbol) && poolpairs.tokenA.fee?.pct !== undefined &&
             <PoolPairDexStabilizationFee fee={poolpairs.tokenA.fee.pct} />}
         </div>
         <div className='flex flex-wrap space-y-12 lg:space-y-0 lg:flex-nowrap mt-8'>

--- a/src/pages/dex/[poolpairId]/index.page.tsx
+++ b/src/pages/dex/[poolpairId]/index.page.tsx
@@ -71,8 +71,8 @@ export default function PoolPairPage (props: InferGetServerSidePropsType<typeof 
         />
         <div className='flex flex-wrap flex-row lg:space-x-4'>
           <PoolPairDetailsBar poolpair={poolpairs} />
-          {['DUSD-DFI', 'dUSDC-DUSD', 'dUSDT-DUSD'].includes(poolpairs.displaySymbol) && poolpairs.tokenA.fee?.pct !== undefined &&
-            <PoolPairDexStabilizationFee fee={poolpairs.tokenA.fee.pct} />}
+          {['DUSD-DFI', 'dUSDC-DUSD', 'dUSDT-DUSD'].includes(poolpairs.displaySymbol) &&
+            <PoolPairDexStabilizationFee fee={poolpairs.tokenA.displaySymbol === 'DUSD' ? poolpairs.tokenA.fee?.pct : poolpairs.tokenB.fee?.pct} />}
         </div>
         <div className='flex flex-wrap space-y-12 lg:space-y-0 lg:flex-nowrap mt-8'>
           <div className='lg:flex lg:flex-col lg:mr-4 w-full lg:w-1/4 min-w-[320px]'>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- Display DEX Stabilization fees on 'DUSD-DFI', 'dUSDC-DUSD', 'dUSDT-DUSD'
- Note as of creating the PR the DEX Stabilization fees on 'dUSDC-DUSD', 'dUSDT-DUSD' is not yet available on mainnet and playground

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Sample Links & Screenshots:
<!--
(Optional) Provide a link to changes made using Netlify Preview deployment.
-->
Link: 
<details>
<summary>Desktop Screenshot</summary>

<!-- Image has to be between break lines -->

</details>
<details>
<summary>Mobile Screenshot</summary>

<!-- Image has to be between break lines -->

</details>

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Tested on multiple web browsers
- [ ] Tested responsiveness (e.g, iPhone, iPad, Desktop)
- [ ] No console errors
- [ ] Unit tests*
- [ ] Added e2e tests*

<!-- 
* If applicable 
-->
