### PR TITLE
chore(ui-ux): fixed Raw Transaction dark mode styles

### DIFF
--- a/src/pages/transactions/_components/RawTransactionHeadings.tsx
+++ b/src/pages/transactions/_components/RawTransactionHeadings.tsx
@@ -10,11 +10,11 @@ export function RawTransactionHeading (props: RawTransactionHeadingProps): JSX.E
   return (
     <>
       <RawTransactionPendingHeading txid={txid} />
-      <span className='leading-6 opacity-60' data-testid='RawTransaction.title'>
+      <span className='leading-6 opacity-60 dark:opacity-100 dark:text-gray-100' data-testid='title'>
         Transaction ID
       </span>
       <div className='flex items-center mt-1'>
-        <h1 className='text-2xl font-medium break-all' data-testid='RawTransaction.txid'>{txid}</h1>
+        <h1 className='text-2xl font-medium break-all dark:text-gray-100' data-testid='RawTransaction.txid'>{txid}</h1>
         <CopyButton className='ml-2' content={txid} />
       </div>
     </>

--- a/src/pages/transactions/_components/RawTransactionVinVout.tsx
+++ b/src/pages/transactions/_components/RawTransactionVinVout.tsx
@@ -17,7 +17,7 @@ export function RawTransactionVinVout (props: RawTransactionVinVoutProps): JSX.E
 
   return (
     <>
-      <h1 className='font-medium text-2xl mt-6' data-testid='RawTransaction.details-subtitle'>Details</h1>
+      <h1 className='font-medium text-2xl mt-6 dark:text-dark-gray-900' data-testid='RawTransaction.details-subtitle'>Details</h1>
       <div className='mt-5 flex flex-col space-y-6 items-start lg:flex-row lg:space-x-8 lg:space-y-0'>
         <div className='w-full lg:w-1/2'>
           <div className='flex flex-col space-y-1' data-testid='RawTransaction.DetailsLeft.List'>
@@ -65,7 +65,7 @@ export function RawTransactionVinVout (props: RawTransactionVinVoutProps): JSX.E
         </div>
       </div>
 
-      <div className='flex flex-col items-end justify-between mt-8'>
+      <div className='flex flex-col items-end justify-between mt-8 dark:text-dark-gray-900'>
         <div className='flex justify-between space-x-3 mt-2' data-testid='RawTransaction.DetailsSummary.total'>
           <span>Total:</span>
           <span>{getTotalVoutValue(props.vouts)} DFI</span>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

A raw transaction page is the first touchpoint a user sees when they tap on the transaction hash from Light Wallet. Even though this state is transient, thought we should fix it.

![image](https://user-images.githubusercontent.com/506667/179887808-38b1b652-a6d1-4440-976c-248f94440400.png)

Did so by copying the `dark` mode styles from the confirmed tx components.


#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes WEB-126

#### Sample Links & Screenshots:
<!--
(Optional) Provide a link to changes made using Netlify Preview deployment.
-->
Link: 
<details>
<summary>Desktop Screenshot</summary>

![image](https://user-images.githubusercontent.com/506667/179888311-f5ec297f-f793-4bed-915c-43f921d7daa5.png)

![image](https://user-images.githubusercontent.com/506667/179888321-c2e97f54-678e-4bc3-ad04-adc92cf3cedd.png)


<!-- Image has to be between break lines -->

</details>
<details>
<summary>Mobile Screenshot</summary>

<!-- Image has to be between break lines -->

</details>

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Tested on multiple web browsers
- [ ] Tested responsiveness (e.g, iPhone, iPad, Desktop)
- [ ] No console errors
- [ ] Unit tests*
- [ ] Added e2e tests*

<!-- 
* If applicable 
-->
