### PR TITLE
chore(dex): invert /dex price calculation to use same price logic as /dex/:id page

### DIFF
--- a/src/pages/dex/_components/PoolPairsTable.tsx
+++ b/src/pages/dex/_components/PoolPairsTable.tsx
@@ -29,7 +29,10 @@ export function PoolPairsTable({
   const { getTokenPrice } = useTokenPrice();
 
   const poolPairsPrices = poolPairs.map((pair) => {
-    const tokenPrice = getTokenPrice(pair.tokenA.symbol, new BigNumber(1));
+    const tokenPrice = getTokenPrice(
+      pair.tokenB.symbol,
+      new BigNumber(pair.priceRatio.ba)
+    );
     return {
       poolPair: pair,
       tokenPrice: tokenPrice,


### PR DESCRIPTION
#### What this PR does / why we need it:

As per the title, this PR changes the calculation of Primary Token Price (USDT) for `/dex` page to follow `/dex/:slug` calculation. Essentially calculation of the value of A based on the value of B using the ratio of ba. While previously, the calculated value of A was based on the value of A using the ratio of ab.
