### PR TITLE
fix(ui-ux): added darkmode text color for futureswap destination

### DIFF
--- a/src/pages/transactions/_components/DfTx/DfTxSetFutureSwap.tsx
+++ b/src/pages/transactions/_components/DfTx/DfTxSetFutureSwap.tsx
@@ -38,7 +38,7 @@ function SetFutureSwapDetailsTable(props: {
         data-testid="DfTxCompositeSwap.SwapFrom"
       >
         <h2
-          className="my-3 font-medium"
+          className="my-3 font-medium dark:text-gray-100"
           data-testid="DfTxCompositeSwap.SwapFromTitle"
         >
           Swap From
@@ -64,7 +64,7 @@ function SetFutureSwapDetailsTable(props: {
         data-testid="DfTxCompositeSwap.SwapTo"
       >
         <h2
-          className="my-3 font-medium"
+          className="my-3 font-medium dark:text-gray-100"
           data-testid="DfTxCompositeSwap.SwapToTitle"
         >
           Swap To


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
This PR fixes the Text Color for darkmode for futureswaps transactions page

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
1. added `dark:text-gray-100` for Swap To and Swap From text

#### Sample Links & Screenshots:
<!--
(Optional) Provide a link to changes made using Netlify Preview deployment.
-->
Link: https://deploy-preview-1489--defi-scan.netlify.app/transactions/f4466fba51463ad2489c9a469a853b5c499d5709e52c6c4f76f3ed168e6e0bd5?network=Playground
<details>
<summary>Desktop Screenshot</summary>
Before
<img width="1604" alt="image" src="https://user-images.githubusercontent.com/57183851/198958596-671c0537-41da-4cd7-b0ea-b596234dd0e9.png">

After 
<img width="1028" alt="image" src="https://user-images.githubusercontent.com/57183851/198958450-247767f0-d8a1-4c81-b0fc-860cda811dc5.png">

<!-- Image has to be between break lines -->

</details>
<details>
<summary>Mobile Screenshot</summary>
Before
<img width="485" alt="image" src="https://user-images.githubusercontent.com/57183851/198958876-9071b380-3ad0-49df-b8ba-1dbc042ac956.png">

After
<img width="485" alt="image" src="https://user-images.githubusercontent.com/57183851/198958772-d2905c7d-369f-43be-a81a-da773c4b2dbc.png">


<!-- Image has to be between break lines -->

</details>

#### Additional comments?:

#### Developer Checklist:
<!--  
Merging into the main branch implies your code is ready for production. 
Before requesting for code review, please ensure that the following tasks 
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Tested on multiple web browsers
- [ ] Tested responsiveness (e.g, iPhone, iPad, Desktop)
- [ ] No console errors
- [ ] Unit tests*
- [ ] Added e2e tests*

<!-- 
* If applicable 
-->
